### PR TITLE
Add pair samplers: utils.real/complex_pair_samples

### DIFF
--- a/functional_algorithms/algorithms.py
+++ b/functional_algorithms/algorithms.py
@@ -97,6 +97,8 @@ def complex_asin(ctx, z: complex):
     # fmt: off
     """Arcus sine on complex input.
 
+    arcsin(z) = 2 * arctan2(z, (1 + sqrt(1 - z * z)))
+
     Here we well use a modified version of the [Hull et
     al]((https://dl.acm.org/doi/10.1145/275323.275324) algorithm with
     a reduced number of approximation regions.
@@ -231,6 +233,10 @@ def real_asin(ctx, x: float):
     """Arcus sine on real input:
 
     arcsin(x) = 2 * arctan2(x, (1 + sqrt(1 - x * x)))
+
+    To avoid cancellation errors at abs(x) close to 1, we'll use
+
+      1 - x * x == (1 - x) * (1 + x)
     """
     return asin(ctx, x)
 

--- a/functional_algorithms/targets/xla_client.py
+++ b/functional_algorithms/targets/xla_client.py
@@ -6,6 +6,8 @@ from .base import PrinterBase
 from .. import utils
 
 source_file_header = """
+#include "xla/client/lib/constants.h"
+#include "xla/client/xla_builder.h"
 #include <limits>
 """
 

--- a/functional_algorithms/tests/test_algorithms.py
+++ b/functional_algorithms/tests/test_algorithms.py
@@ -6,7 +6,7 @@ from functional_algorithms import Context, targets, algorithms, utils
 import pytest
 
 
-@pytest.fixture(scope="function", params=["python", "numpy", "stablehlo", "xla_client"])
+@pytest.fixture(scope="function", params=["python", "numpy", "stablehlo", "xla_client", "cpp"])
 def target_name(request):
     return request.param
 
@@ -79,11 +79,12 @@ def test_binary(dtype_name, binary_func_name):
     reference = getattr(utils.numpy_with_mpmath(extra_prec_multiplier=10), binary_func_name)
 
     if dtype in {numpy.complex64, numpy.complex128}:
-        samples = utils.complex_samples((26, 26), dtype=dtype, include_huge=True).flatten()
-        samples = [(sample, sample) for sample in samples]  # TODO: make better samples
+        samples1, samples2 = utils.complex_pair_samples(((26, 26), (13, 13)), dtype=dtype, include_huge=True)
+        samples = [(x, y) for x, y in zip(samples1, samples2)]
     else:
-        samples = utils.complex_samples((26, 26), dtype=dtype, include_huge=True).flatten()
-        samples = [(x, y) for x, y in zip(samples.real, samples.imag)]
+        samples1, samples2 = utils.real_pair_samples((26, 26), dtype=dtype, include_huge=True)
+        samples = [(x, y) for x, y in zip(samples1, samples2)]
+
     matches_with_reference, _ = utils.validate_function(func, reference, samples, dtype)
     assert matches_with_reference  # warning: also reference may be wrong
 

--- a/functional_algorithms/utils.py
+++ b/functional_algorithms/utils.py
@@ -428,8 +428,8 @@ def real_samples(
     include_zero=True,
     include_subnormal=False,
     include_nan=False,
-    nonnegative=False,
     include_huge=True,
+    nonnegative=False,
 ):
     """Return a 1-D array of real line samples.
 
@@ -439,12 +439,20 @@ def real_samples(
       Initial size of the samples array. A minimum value is 6. The
       actual size of the returned array may differ from size.
     dtype:
+      Floating-point type: float32, float64.
     include_infinity: bool
+      When True, samples include signed infinities.
     include_zero: bool
+      When True, samples include zero.
     include_subnormal: bool
+      When True, samples include subnormal numbers.
     include_nan: bool
-    nonnegative: bool
+      When True, samples include nan.
     include_huge: bool
+      When True, samples include a value that has 1 ULP smaller than
+      maximal value.
+    nonnegative: bool
+      When True, finite samples are all non-negative.
     """
     if isinstance(dtype, str):
         dtype = getattr(numpy, dtype)
@@ -499,7 +507,6 @@ def complex_samples(
     include_subnormal: bool
     include_nan: bool
     nonnegative: bool
-
     """
     if isinstance(dtype, str):
         dtype = getattr(numpy, dtype)
@@ -530,6 +537,105 @@ def complex_samples(
     imag_part.real[:] = 0
     imag_part = imag_part.reshape((im.size, -1)).repeat(re.size, 1)
     return real_part + imag_part  # TODO: avoid arithmetic operations
+
+
+def real_pair_samples(
+    size=(10, 10),
+    dtype=numpy.float32,
+    include_infinity=True,
+    include_zero=True,
+    include_subnormal=False,
+    include_nan=False,
+    include_huge=True,
+    nonnegative=False,
+):
+    """Return a pair of 1-D arrays of real line samples.
+
+    Parameters
+    ----------
+    size : tuple(int, int)
+      Initial size of the samples array. A minimum value is (6, 6). The
+      actual size of the returned array is approximately size[0] * size[1].
+    dtype:
+    include_infinity: bool
+    include_zero: bool
+    include_subnormal: bool
+    include_nan: bool
+    nonnegative: bool
+    """
+    s1 = real_samples(
+        size=size[0],
+        dtype=dtype,
+        include_infinity=include_infinity,
+        include_zero=include_zero,
+        include_subnormal=include_subnormal,
+        include_nan=include_nan,
+        nonnegative=nonnegative,
+        include_huge=include_huge,
+    )
+    s2 = real_samples(
+        size=size[1],
+        dtype=dtype,
+        include_infinity=include_infinity,
+        include_zero=include_zero,
+        include_subnormal=include_subnormal,
+        include_nan=include_nan,
+        nonnegative=nonnegative,
+        include_huge=include_huge,
+    )
+    s1, s2 = s1.reshape(1, -1).repeat(s2.size, 0).flatten(), s2.repeat(s1.size)
+    return s1, s2
+
+
+def complex_pair_samples(
+    size=((10, 10), (10, 10)),
+    dtype=numpy.float32,
+    include_infinity=True,
+    include_zero=True,
+    include_subnormal=False,
+    include_nan=False,
+    include_huge=True,
+    nonnegative=False,
+):
+    """Return a pair of 2-D arrays of complex plane samples.
+
+    Parameters
+    ----------
+    size : tuple(tuple(int, int), tuple(int, int))
+      Initial size of the samples array. A minimum value is ((6, 6),
+      (6, 6)). The actual size of the returned array is approximately
+      (size[0][0] * size[1][0], size[0][1] * size[1][1]).
+    dtype:
+    include_infinity: bool
+    include_zero: bool
+    include_subnormal: bool
+    include_nan: bool
+    nonnegative: bool
+    """
+    s1 = complex_samples(
+        size=size[0],
+        dtype=dtype,
+        include_infinity=include_infinity,
+        include_zero=include_zero,
+        include_subnormal=include_subnormal,
+        include_nan=include_nan,
+        nonnegative=nonnegative,
+        include_huge=include_huge,
+    )
+    s2 = complex_samples(
+        size=size[1],
+        dtype=dtype,
+        include_infinity=include_infinity,
+        include_zero=include_zero,
+        include_subnormal=include_subnormal,
+        include_nan=include_nan,
+        nonnegative=nonnegative,
+        include_huge=include_huge,
+    )
+    shape1 = s1.shape
+    shape2 = s2.shape
+    s1, s2 = numpy.tile(s1, shape2), s2.repeat(shape1[0], 0).repeat(shape1[1], 1)
+    return s1, s2
 
 
 def iscomplex(value):


### PR DESCRIPTION
As in the title. Pair samplers can be used when testing binary operations.