### PR TITLE
Add sqrt using native implementation.

### DIFF
--- a/functional_algorithms/algorithms.py
+++ b/functional_algorithms/algorithms.py
@@ -644,3 +644,7 @@ def acosh(ctx, z: complex | float):
     if z.is_complex:
         return complex_acosh(ctx, z)
     return real_acosh(ctx, z)
+
+
+def sqrt(ctx, z: complex | float):
+    return ctx.sqrt(z)

--- a/functional_algorithms/tests/test_algorithms.py
+++ b/functional_algorithms/tests/test_algorithms.py
@@ -16,12 +16,12 @@ def dtype_name(request):
     return request.param
 
 
-@pytest.fixture(scope="function", params=["absolute", "acos", "acosh", "asin", "asinh", "hypot", "square"])
+@pytest.fixture(scope="function", params=["absolute", "acos", "acosh", "asin", "asinh", "hypot", "square", "sqrt"])
 def func_name(request):
     return request.param
 
 
-@pytest.fixture(scope="function", params=["absolute", "acos", "acosh", "asin", "asinh", "square"])
+@pytest.fixture(scope="function", params=["absolute", "acos", "acosh", "asin", "asinh", "square", "sqrt"])
 def unary_func_name(request):
     return request.param
 

--- a/functional_algorithms/utils.py
+++ b/functional_algorithms/utils.py
@@ -497,6 +497,19 @@ class mpmath_array_api:
                 return ctx.nan
         return ctx.acosh(x)
 
+    def sqrt(self, x):
+        ctx = x.context
+        if isinstance(x, ctx.mpc):
+            # Workaround mpmath 1.3 bug in sqrt(a+-infj) evaluation
+            # (see mpmath/mpmath#776)
+            if ctx.isinf(x.imag):
+                return ctx.make_mpc((ctx.inf._mpf_, x.imag._mpf_))
+        else:
+            if x < 0:
+                # otherwise, mpmath.sqrt would return complex value
+                return ctx.nan
+        return ctx.sqrt(x)
+
 
 class numpy_with_mpmath:
     """Namespace of universal functions on numpy arrays that use mpmath

--- a/results/README.md
+++ b/results/README.md
@@ -32,3 +32,7 @@ MPMath functions using multi-precision arithmetic.
 | square | float64 | 999593 | 408 | - | - | - | - |
 | square | complex64 | 976809 | 25192 | - | - | - | - |
 | square | complex128 | 995833 | 6168 | - | - | - | - |
+| sqrt | float32 | 1000001 | - | - | - | - | - |
+| sqrt | float64 | 1000001 | - | - | - | - | - |
+| sqrt | complex64 | 639749 | 362152 | 100 | - | - | - |
+| sqrt | complex128 | 653493 | 348492 | 16 | - | - | - |

--- a/results/estimate_accuracy.py
+++ b/results/estimate_accuracy.py
@@ -35,6 +35,10 @@ def get_inputs():
         ("square", np.float64, {}),
         ("square", np.complex64, {}),
         ("square", np.complex128, {}),
+        ("sqrt", np.float32, {}),
+        ("sqrt", np.float64, {}),
+        ("sqrt", np.complex64, {}),
+        ("sqrt", np.complex128, {}),
     ]:
         if parameters:
             params = "[" + ", ".join(f"{k}={v}" for k, v in parameters.items()) + "]"
@@ -87,6 +91,8 @@ MPMath functions using multi-precision arithmetic.
 
         if func_name in {"asin", "asinh", "acos", "acosh"}:
             extra_prec_multiplier = 20
+        elif func_name in {"sqrt"}:
+            extra_prec_multiplier = 2
         else:
             extra_prec_multiplier = 1
         reference = getattr(


### PR DESCRIPTION
As in the title.

This is useful mostly for giving accuracy information about native sqrt. As it turns out, native sqrt on complex inputs may have room from improving accuracy while sqrt on real inputs is accurate within the given fp-system.