### PR TITLE
Improve the accuracy of real acos

### DIFF
--- a/functional_algorithms/rewrite.py
+++ b/functional_algorithms/rewrite.py
@@ -1,3 +1,4 @@
+import math
 from . import expr as _expr
 
 
@@ -284,8 +285,13 @@ class Rewriter:
             xvalue, xlike = x.operands
             yvalue, ylike = y.operands
 
-            if isinstance(xvalue, (int, float)) and isinstance(yvalue, (int, float)):
+            if isinstance(yvalue, str):
+                if yvalue == "posinf":
+                    yvalue = math.inf
+                if yvalue == "neginf":
+                    yvalue = -math.inf
 
+            if isinstance(xvalue, (int, float)) and isinstance(yvalue, (int, float)):
                 r = relop(xvalue, yvalue)
                 ctx = expr.context
                 return ctx.constant(r, ctx.symbol(None, "boolean"))

--- a/results/README.md
+++ b/results/README.md
@@ -12,8 +12,8 @@ MPMath functions using multi-precision arithmetic.
 | absolute | float64 | 1000001 | - | - | - | - | - |
 | absolute | complex64 | 967753 | 33696 | 552 | - | - | - |
 | absolute | complex128 | 991753 | 10104 | 144 | - | - | - |
-| acos | float32 | 548396 | 444291 | 7072 | 242 | - | - |
-| acos | float64 | 985930 | 12727 | 1338 | 6 | - | - |
+| acos | float32 | 961608 | 38291 | 99 | 3 | - | - |
+| acos | float64 | 992582 | 7416 | 3 | - | - | - |
 | acos | complex64 | 810108 | 191263 | 622 | 8 | - | - |
 | acos | complex128 | 690209 | 311554 | 238 | - | - | - |
 | acosh | float32 | 988269 | 11704 | 28 | - | - | - |

--- a/results/cpp/acos.cpp
+++ b/results/cpp/acos.cpp
@@ -12,21 +12,13 @@
 
 
 float acos_0(float z) {
-  float one = 1;
-  float add_one_z = (one) + (z);
-  return (((z) != (-1))
-              ? ((2) * (std::atan2(std::sqrt(((one) - (z)) * (add_one_z)),
-                                   add_one_z)))
-              : (M_PI));
+  float constant_1 = 1;
+  return std::atan2(std::sqrt(((constant_1) - (z)) * ((constant_1) + (z))), z);
 }
 
 double acos_1(double z) {
-  double one = 1;
-  double add_one_z = (one) + (z);
-  return (((z) != (-1))
-              ? ((2) * (std::atan2(std::sqrt(((one) - (z)) * (add_one_z)),
-                                   add_one_z)))
-              : (M_PI));
+  double constant_1 = 1;
+  return std::atan2(std::sqrt(((constant_1) - (z)) * ((constant_1) + (z))), z);
 }
 
 std::complex<float> acos_2(std::complex<float> z) {

--- a/results/numpy/acos.py
+++ b/results/numpy/acos.py
@@ -216,24 +216,14 @@ def acos_1(z: numpy.complex64) -> numpy.complex64:
 def acos_2(z: numpy.float64) -> numpy.float64:
     with warnings.catch_warnings(action="ignore"):
         z = numpy.float64(z)
-        one: numpy.float64 = numpy.float64(1)
-        add_one_z: numpy.float64 = (one) + (z)
-        result = (
-            ((numpy.float64(2)) * (numpy.arctan2(numpy.sqrt(((one) - (z)) * (add_one_z)), add_one_z)))
-            if ((z) != (numpy.float64(-1)))
-            else (numpy.float64(numpy.float64(numpy.pi)))
-        )
+        constant_1: numpy.float64 = numpy.float64(1)
+        result = numpy.arctan2(numpy.sqrt(((constant_1) - (z)) * ((constant_1) + (z))), z)
         return result
 
 
 def acos_3(z: numpy.float32) -> numpy.float32:
     with warnings.catch_warnings(action="ignore"):
         z = numpy.float32(z)
-        one: numpy.float32 = numpy.float32(1)
-        add_one_z: numpy.float32 = (one) + (z)
-        result = (
-            ((numpy.float32(2)) * (numpy.arctan2(numpy.sqrt(((one) - (z)) * (add_one_z)), add_one_z)))
-            if ((z) != (numpy.float32(-1)))
-            else (numpy.float32(numpy.float32(numpy.pi)))
-        )
+        constant_1: numpy.float32 = numpy.float32(1)
+        result = numpy.arctan2(numpy.sqrt(((constant_1) - (z)) * ((constant_1) + (z))), z)
         return result

--- a/results/python/acos.py
+++ b/results/python/acos.py
@@ -94,6 +94,5 @@ def acos_0(z: complex) -> complex:
 
 
 def acos_1(z: float) -> float:
-    one: float = 1
-    add_one_z: float = (one) + (z)
-    return ((2) * (math.atan2(math.sqrt(((one) - (z)) * (add_one_z)), add_one_z))) if ((z) != (-1)) else (math.pi)
+    constant_1: float = 1
+    return math.atan2(math.sqrt(((constant_1) - (z)) * ((constant_1) + (z))), z)

--- a/results/stablehlo/acos.td
+++ b/results/stablehlo/acos.td
@@ -6,23 +6,14 @@
 
 
 def : Pat<(acos_0 NonComplexElementType:$z),
-  (StableHLO_SelectOp
-    (StableHLO_CompareOp
-     $z,
-     (StableHLO_ConstantLike<"-1"> $z),
-      StableHLO_ComparisonDirectionValue<"NE">,
-      (STABLEHLO_DEFAULT_COMPARISON_TYPE)),
-    (StableHLO_MulOp
-      (StableHLO_ConstantLike<"2"> $z),
-      (StableHLO_Atan2Op
-        (StableHLO_SqrtOp
-          (StableHLO_MulOp
-            (StableHLO_SubtractOp
-              (StableHLO_ConstantLike<"1">:$one $z),
-              $z),
-            (StableHLO_AddOp:$add_one_z $one, $z))),
-        $add_one_z)),
-    (StableHLO_ConstantLike<"M_PI"> $z))>;
+  (StableHLO_Atan2Op
+    (StableHLO_SqrtOp
+      (StableHLO_MulOp
+        (StableHLO_SubtractOp
+          (StableHLO_ConstantLike<"1">:$constant_1 $z),
+          $z),
+        (StableHLO_AddOp $constant_1, $z))),
+    $z)>;
 
 def : Pat<(acos_1 ComplexElementType:$z),
   (StableHLO_ComplexOp

--- a/results/xla_client/acos.cc
+++ b/results/xla_client/acos.cc
@@ -11,12 +11,9 @@
 
 template <typename FloatType>
 XlaOp acos_0(XlaOp z) {
-  XlaOp one = ScalarLike(z, 1);
-  XlaOp add_one_z = Add(one, z);
-  return Select(Ne(z, ScalarLike(z, -1)),
-                Mul(ScalarLike(z, 2),
-                    Atan2(Sqrt(Mul(Sub(one, z), add_one_z)), add_one_z)),
-                ScalarLike(z, M_PI));
+  XlaOp constant_constant_1 = ScalarLike(z, 1);
+  return Atan2(
+      Sqrt(Mul(Sub(constant_constant_1, z), Add(constant_constant_1, z))), z);
 }
 
 template <typename FloatType>

--- a/results/xla_client/real_acos.cc
+++ b/results/xla_client/real_acos.cc
@@ -11,10 +11,7 @@
 
 template <typename FloatType>
 XlaOp real_acos_0(XlaOp x) {
-  XlaOp one = ScalarLike(x, 1);
-  XlaOp add_one_x = Add(one, x);
-  return Select(Ne(x, ScalarLike(x, -1)),
-                Mul(ScalarLike(x, 2),
-                    Atan2(Sqrt(Mul(Sub(one, x), add_one_x)), add_one_x)),
-                ScalarLike(x, M_PI));
+  XlaOp constant_constant_1 = ScalarLike(x, 1);
+  return Atan2(
+      Sqrt(Mul(Sub(constant_constant_1, x), Add(constant_constant_1, x))), x);
 }


### PR DESCRIPTION
As in the title:
```
-| acos | float32 | 548396 | 444291 | 7072 | 242 | - | - |
-| acos | float64 | 985930 | 12727 | 1338 | 6 | - | - |
+| acos | float32 | 961608 | 38291 | 99 | 3 | - | - |
+| acos | float64 | 992582 | 7416 | 3 | - | - | - |
```

The trick is to use identity `arccos(x) = arctan2(sqrt(1 - x*x), x)`. Btw, this is the formula to which Hull et al algorithm also reduces when restricting to the real line.