### PR TITLE
Add complex log1p

### DIFF
--- a/functional_algorithms/targets/cpp.py
+++ b/functional_algorithms/targets/cpp.py
@@ -17,6 +17,7 @@ source_file_header = """
 trace_arguments = dict(
     square=[(":float32",), (":float64",), (":complex64",), (":complex128",)],
     absolute=[(":float32",), (":float64",), (":complex64",), (":complex128",)],
+    log1p=[(":float32",), (":float64",), (":complex64",), (":complex128",)],
     hypot=[(":float32", ":float32"), (":float64", ":float64")],
     asin_acos_kernel=[(":complex64",), (":complex128",)],
     acos=[(":float32",), (":float64",), (":complex64",), (":complex128",)],

--- a/functional_algorithms/targets/numpy.py
+++ b/functional_algorithms/targets/numpy.py
@@ -31,6 +31,7 @@ trace_arguments = dict(
     acosh=[(":complex128",), (":complex64",), (":float64",), (":float32",)],
     asin=[(":complex128",), (":complex64",), (":float64",), (":float32",)],
     asinh=[(":complex128",), (":complex64",), (":float64",), (":float32",)],
+    log1p=[(":complex128",), (":complex64",), (":float64",), (":float32",)],
     hypot=[(":float32", ":float32"), (":float64", ":float64")],
     square=[(":complex128",), (":complex64",), (":float64",), (":float32",)],
 )

--- a/functional_algorithms/targets/python.py
+++ b/functional_algorithms/targets/python.py
@@ -26,6 +26,7 @@ trace_arguments = dict(
     asinh=[(":complex",), (":float",)],
     hypot=[(":float", ":float")],
     square=[(":float",), (":complex",)],
+    log1p=[(":float",), (":complex",)],
 )
 
 

--- a/functional_algorithms/targets/stablehlo.py
+++ b/functional_algorithms/targets/stablehlo.py
@@ -15,6 +15,7 @@ trace_arguments = dict(
     acosh=[(":float",), (":complex",)],
     asin=[(":float",), (":complex",)],
     asinh=[(":float",), (":complex",)],
+    log1p=[(":float",), (":complex",)],
     hypot=[(":float", ":float")],
     square=[(":float",), (":complex",)],
 )

--- a/functional_algorithms/targets/xla_client.py
+++ b/functional_algorithms/targets/xla_client.py
@@ -28,6 +28,7 @@ trace_arguments = dict(
     acosh=[(":float", ":float"), (":complex", ":complex")],
     asin=[(":float", ":float"), (":complex", ":complex")],
     asinh=[(":float", ":float"), (":complex", ":complex")],
+    complex_log1p=[(":complex", ":complex")],
 )
 
 source_file_extension = ".cc"

--- a/functional_algorithms/tests/test_algorithms.py
+++ b/functional_algorithms/tests/test_algorithms.py
@@ -21,7 +21,7 @@ def func_name(request):
     return request.param
 
 
-@pytest.fixture(scope="function", params=["absolute", "acos", "acosh", "asin", "asinh", "square", "sqrt", "angle"])
+@pytest.fixture(scope="function", params=["absolute", "acos", "acosh", "asin", "asinh", "square", "sqrt", "angle", "log1p"])
 def unary_func_name(request):
     return request.param
 
@@ -50,6 +50,8 @@ def test_unary(dtype_name, unary_func_name, flush_subnormals):
 
     if unary_func_name in {"acos", "asin", "asinh", "acosh"}:
         extra_prec_multiplier = 20
+    elif unary_func_name in {"log1p", "sqrt"}:
+        extra_prec_multiplier = 2
     else:
         extra_prec_multiplier = 1
     reference = getattr(

--- a/functional_algorithms/utils.py
+++ b/functional_algorithms/utils.py
@@ -344,15 +344,25 @@ class mpmath_array_api:
             # Workaround mpmath 1.3 bug in log(+-inf+-infj) evaluation (see mpmath/mpmath#774).
             if ctx.isinf(x.real) and ctx.isinf(x.imag):
                 pi = ctx.pi
-            if x.real > 0 and x.imag > 0:
-                return ctx.make_mpc((x.real._mpf_, (pi / 4)._mpf_))
-            if x.real > 0 and x.imag < 0:
-                return ctx.make_mpc((x.real._mpf_, (-pi / 4)._mpf_))
-            if x.real < 0 and x.imag < 0:
-                return ctx.make_mpc(((-x.real)._mpf_, (-3 * pi / 4)._mpf_))
-            if x.real < 0 and x.imag > 0:
-                return ctx.make_mpc(((-x.real)._mpf_, (3 * pi / 4)._mpf_))
-        return ctx.log1p(x)
+                if x.real > 0 and x.imag > 0:
+                    return ctx.make_mpc((x.real._mpf_, (pi / 4)._mpf_))
+                if x.real > 0 and x.imag < 0:
+                    return ctx.make_mpc((x.real._mpf_, (-pi / 4)._mpf_))
+                if x.real < 0 and x.imag < 0:
+                    return ctx.make_mpc(((-x.real)._mpf_, (-3 * pi / 4)._mpf_))
+                if x.real < 0 and x.imag > 0:
+                    return ctx.make_mpc(((-x.real)._mpf_, (3 * pi / 4)._mpf_))
+        else:
+            if x < -1:
+                # otherwise, mpmath.log1p returns a complex value
+                return ctx.nan
+
+        r = ctx.log1p(x)
+        if isinstance(x, ctx.mpc):
+            if isinstance(r, ctx.mpf):
+                # Workaround log1p(0j) -> 0
+                r = ctx.make_mpc((r._mpf_, ctx.zero._mpf_))
+        return r
 
     def tan(self, x):
         ctx = x.context

--- a/functional_algorithms/utils.py
+++ b/functional_algorithms/utils.py
@@ -1,5 +1,6 @@
 import itertools
 import numpy
+import math
 import mpmath
 import multiprocessing
 import os

--- a/results/README.md
+++ b/results/README.md
@@ -38,5 +38,5 @@ MPMath functions using multi-precision arithmetic.
 | sqrt | complex128 | 653493 | 348492 | 16 | - | - | - |
 | angle | complex64 | 940281 | 61338 | 378 | 4 | - | - |
 | angle | complex128 | 989725 | 12276 | - | - | - | - |
-| log1p | complex64 | 902293 | 97834 | 1582 | 102 | 190 | - |
-| log1p | complex128 | 801442 | 200039 | 78 | 8 | 434 | - |
+| log1p | complex64 | 902287 | 97840 | 1582 | 102 | 190 | - |
+| log1p | complex128 | 801864 | 200067 | 64 | 6 | - | - |

--- a/results/README.md
+++ b/results/README.md
@@ -1,42 +1,74 @@
 
 # Accuracy of provided algorithms
 
-The following table shows the counts of samples that produce function
-values being different from expected values by the given ULP
-difference (dULP). The expected values are obtained by evaluating
-MPMath functions using multi-precision arithmetic.
+<sub>This file is generated using estimate_accuracy.py. Do not edit!</sub>
 
-| Function | dtype | dULP=0 (exact) | dULP=1 | dULP=2 | dULP=3 | dULP>3 | errors    |
-| -------- | ----- | ------------- | ----- | ----- | ----- | ----- | --------- |
-| absolute | float32 | 1000001 | - | - | - | - | - |
-| absolute | float64 | 1000001 | - | - | - | - | - |
-| absolute | complex64 | 967753 | 33696 | 552 | - | - | - |
-| absolute | complex128 | 991753 | 10104 | 144 | - | - | - |
-| acos | float32 | 961608 | 38291 | 99 | 3 | - | - |
-| acos | float64 | 992582 | 7416 | 3 | - | - | - |
-| acos | complex64 | 810108 | 191263 | 622 | 8 | - | - |
-| acos | complex128 | 690209 | 311554 | 238 | - | - | - |
-| acosh | float32 | 988269 | 11704 | 28 | - | - | - |
-| acosh | float64 | 946246 | 53752 | 3 | - | - | - |
-| acosh | complex64 | 810108 | 191263 | 622 | 8 | - | - |
-| acosh | complex128 | 690209 | 311554 | 238 | - | - | - |
-| asin | float32 | 974679 | 24368 | 942 | 12 | - | - |
-| asin | float64 | 995197 | 4776 | 28 | - | - | - |
-| asin | complex64 | 807415 | 193174 | 1320 | 92 | - | - |
-| asin | complex128 | 687179 | 313978 | 844 | - | - | - |
-| asinh | float32 | 916129 | 83790 | 82 | - | - | - |
-| asinh | float64 | 825453 | 174482 | 66 | - | - | - |
-| asinh | complex64 | 807415 | 193174 | 1320 | 92 | - | - |
-| asinh | complex128 | 687179 | 313978 | 844 | - | - | - |
-| square | float32 | 997347 | 2654 | - | - | - | - |
-| square | float64 | 999593 | 408 | - | - | - | - |
-| square | complex64 | 976809 | 25192 | - | - | - | - |
-| square | complex128 | 995833 | 6168 | - | - | - | - |
-| sqrt | float32 | 1000001 | - | - | - | - | - |
-| sqrt | float64 | 1000001 | - | - | - | - | - |
-| sqrt | complex64 | 639749 | 362152 | 100 | - | - | - |
-| sqrt | complex128 | 653493 | 348492 | 16 | - | - | - |
-| angle | complex64 | 940281 | 61338 | 378 | 4 | - | - |
-| angle | complex128 | 989725 | 12276 | - | - | - | - |
-| log1p | complex64 | 902287 | 97840 | 1582 | 102 | 190 | - |
-| log1p | complex128 | 801864 | 200067 | 64 | 6 | - | - |
+The reference values are obtained by evaluating MPMath functions using
+multi-precision arithmetic.
+
+The following table shows the counts of samples that produce function
+values being
+- different from expected values by the given ULP difference (dULP):
+  ```
+  ulp_diff(func(sample), reference(sample)) == dULP
+  ```
+
+- out of the reference values ulp-range:
+  ```
+  not (lower <= func(sample) <= upper)
+  lower = minimal(reference(s) for s in surrounding(sample) if diff_ulp(s, sample) <= ulp_width)
+  upper = maximal(reference(s) for s in surrounding(sample) if diff_ulp(s, sample) <= ulp_width)
+  ```
+
+When a counts value is attributed with a superscript, this indicates
+the number of samples that lead to out-of-ulp-range results. When dULP
+<= 3, out-of-ulp-range counts are acceptable as it typically indicates
+that reference function is not sensitive to input perturbations, that
+is, `lower == reference(sample) == upper` holds. On the other hand,
+when the out-of-ulp-range counts is zero, dULP > 3 counts are
+acceptable as it indicates that function's variability is very high
+with respect to minimal variations in its input.
+
+When `ulp_width` is specified, its value is indicated as a superscript
+in function name. Notice the specified `ulp_width` is not the upper
+limit in general: there may exist function-function dependent regions
+in complex plane where `ulp_width` needs to be larger to pass the
+"out-of-ulp-range counts is zero" test.
+
+
+| Function | dtype | dULP=0 (exact) | dULP=1 | dULP=2 | dULP=3 | dULP>3 |
+| -------- | ----- | -------------- | ------ | ------ | ------ | ------ |
+| absolute | complex64 | 967753 | 33696 | 552 | - | - |
+| absolute | complex128 | 991753 | 10104 | 144 | - | - |
+| acos | float32 | 961608 | 38291 | 99 | 3 | - |
+| acos | float64 | 992582 | 7416 | 3 | - | - |
+| acos | complex64 | 810108 | 191263 | 622 | 8 | - |
+| acos | complex128 | 690209 | 311554 | 238 | - | - |
+| acosh | float32 | 988269 | 11704 | 28 | - | - |
+| acosh | float64 | 946246 | 53752 | 3 | - | - |
+| acosh | complex64 | 810108 | 191263 | 622 | 8 | - |
+| acosh | complex128 | 690209 | 311554 | 238 | - | - |
+| asin | float32 | 974679 | 24368 | 942 | 12 | - |
+| asin | float64 | 995197 | 4776 | 28 | - | - |
+| asin | complex64 | 807415 | 193174 | 1320 | 92 | - |
+| asin | complex128 | 687179 | 313978 | 844 | - | - |
+| asinh | float32 | 916129 | 83790 | 82 | - | - |
+| asinh | float64 | 825453 | 174482 | 66 | - | - |
+| asinh | complex64 | 807415 | 193174 | 1320 | 92 | - |
+| asinh | complex128 | 687179 | 313978 | 844 | - | - |
+| square | float32 | 997347 | 2654 | - | - | - |
+| square | float64 | 999593 | 408 | - | - | - |
+| square | complex64 | 976809 | 25192 | - | - | - |
+| square | complex128 | 995833 | 6168 | - | - | - |
+| sqrt | float32 | 1000001 | - | - | - | - |
+| sqrt | float64 | 1000001 | - | - | - | - |
+| sqrt | complex64 | 639749 | 362152 | 100 | - | - |
+| sqrt | complex128 | 653493 | 348492 | 16 | - | - |
+| angle | complex64 | 940281 | 61338 | 378 | 4 | - |
+| angle | complex128 | 989725 | 12276 | - | - | - |
+| log1p | float32 | 987438 | 12549 | 14 | - | - |
+| log1p | float64 | 945368 | 54622 | 11 | - | - |
+| log1p<sup>1</sup> | complex64 | 902287 | 97840<sup>47722</sup> | 1582<sup>1168</sup> | 102<sup>28</sup> | 190<sup>22</sup>!! |
+| log1p<sup>2</sup> | complex64 | 902287 | 97840<sup>42698</sup> | 1582<sup>72</sup> | 102<sup>6</sup> | 190<sup>2</sup>!! |
+| log1p<sup>3</sup> | complex64 | 902287 | 97840<sup>41454</sup> | 1582<sup>44</sup> | 102 | 190 |
+| log1p<sup>1</sup> | complex128 | 801864 | 200067<sup>188447</sup> | 64<sup>10</sup> | 6 | - |

--- a/results/README.md
+++ b/results/README.md
@@ -38,3 +38,5 @@ MPMath functions using multi-precision arithmetic.
 | sqrt | complex128 | 653493 | 348492 | 16 | - | - | - |
 | angle | complex64 | 940281 | 61338 | 378 | 4 | - | - |
 | angle | complex128 | 989725 | 12276 | - | - | - | - |
+| log1p | complex64 | 902293 | 97834 | 1582 | 102 | 190 | - |
+| log1p | complex128 | 801442 | 200039 | 78 | 8 | 434 | - |

--- a/results/cpp/log1p.cpp
+++ b/results/cpp/log1p.cpp
@@ -1,0 +1,48 @@
+// This file is generated using functional_algorithms tool (0.4.0), see
+//   https://github.com/pearu/functional_algorithms
+// for more information.
+
+
+
+#include <algorithm>
+#include <cmath>
+#include <complex>
+#include <cstdint>
+#include <limits>
+
+
+float log1p_0(float z) { return std::log1p(z); }
+
+double log1p_1(double z) { return std::log1p(z); }
+
+std::complex<float> log1p_2(std::complex<float> z) {
+  float x = (z).real();
+  float one = 1;
+  float xp1 = (x) + (one);
+  float y = (z).imag();
+  float ay = std::abs(y);
+  float axp1 = std::abs(xp1);
+  float mx = std::max(axp1, ay);
+  float mn = std::min(axp1, ay);
+  float r = (mn) / (mx);
+  return std::complex<float>(
+      (std::log1p((((xp1) >= (ay)) ? (x) : ((mx) - (one))))) +
+          ((0.5) * (std::log1p((((mn) == (mx)) ? (one) : ((r) * (r)))))),
+      std::atan2(y, xp1));
+}
+
+std::complex<double> log1p_3(std::complex<double> z) {
+  double x = (z).real();
+  double one = 1;
+  double xp1 = (x) + (one);
+  double y = (z).imag();
+  double ay = std::abs(y);
+  double axp1 = std::abs(xp1);
+  double mx = std::max(axp1, ay);
+  double mn = std::min(axp1, ay);
+  double r = (mn) / (mx);
+  return std::complex<double>(
+      (std::log1p((((xp1) >= (ay)) ? (x) : ((mx) - (one))))) +
+          ((0.5) * (std::log1p((((mn) == (mx)) ? (one) : ((r) * (r)))))),
+      std::atan2(y, xp1));
+}

--- a/results/estimate_accuracy.py
+++ b/results/estimate_accuracy.py
@@ -95,8 +95,10 @@ MPMath functions using multi-precision arithmetic.
 
         if func_name in {"asin", "asinh", "acos", "acosh"}:
             extra_prec_multiplier = 20
-        elif func_name in {"sqrt", "log1p"}:
+        elif func_name in {"sqrt"}:
             extra_prec_multiplier = 2
+        elif func_name in {"log1p"}:
+            extra_prec_multiplier = 10
         else:
             extra_prec_multiplier = 1
         reference = getattr(

--- a/results/estimate_accuracy.py
+++ b/results/estimate_accuracy.py
@@ -41,6 +41,8 @@ def get_inputs():
         ("sqrt", np.complex128, {}),
         ("angle", np.complex64, {}),
         ("angle", np.complex128, {}),
+        ("log1p", np.complex64, {}),
+        ("log1p", np.complex128, {}),
     ]:
         if parameters:
             params = "[" + ", ".join(f"{k}={v}" for k, v in parameters.items()) + "]"
@@ -93,7 +95,7 @@ MPMath functions using multi-precision arithmetic.
 
         if func_name in {"asin", "asinh", "acos", "acosh"}:
             extra_prec_multiplier = 20
-        elif func_name in {"sqrt"}:
+        elif func_name in {"sqrt", "log1p"}:
             extra_prec_multiplier = 2
         else:
             extra_prec_multiplier = 1

--- a/results/numpy/log1p.py
+++ b/results/numpy/log1p.py
@@ -1,0 +1,69 @@
+# This file is generated using functional_algorithms tool (0.4.0), see
+#   https://github.com/pearu/functional_algorithms
+# for more information.
+
+
+import numpy
+import warnings
+
+
+def make_complex(r, i):
+    if r.dtype == numpy.float32 and i.dtype == numpy.float32:
+        return numpy.array([r, i]).view(numpy.complex64)[0]
+    elif i.dtype == numpy.float64 and i.dtype == numpy.float64:
+        return numpy.array([r, i]).view(numpy.complex128)[0]
+    raise NotImplementedError((r.dtype, i.dtype))
+
+
+def log1p_0(z: numpy.complex128) -> numpy.complex128:
+    with warnings.catch_warnings(action="ignore"):
+        z = numpy.complex128(z)
+        x: numpy.float64 = (z).real
+        one: numpy.float64 = numpy.float64(1)
+        xp1: numpy.float64 = (x) + (one)
+        y: numpy.float64 = (z).imag
+        ay: numpy.float64 = numpy.abs(y)
+        axp1: numpy.float64 = numpy.abs(xp1)
+        mx: numpy.float64 = max(axp1, ay)
+        mn: numpy.float64 = min(axp1, ay)
+        r: numpy.float64 = (mn) / (mx)
+        result = make_complex(
+            (numpy.log1p((x) if ((xp1) >= (ay)) else ((mx) - (one))))
+            + ((numpy.float64(0.5)) * (numpy.log1p((one) if (numpy.equal(mn, mx, dtype=numpy.bool_)) else ((r) * (r))))),
+            numpy.arctan2(y, xp1),
+        )
+        return result
+
+
+def log1p_1(z: numpy.complex64) -> numpy.complex64:
+    with warnings.catch_warnings(action="ignore"):
+        z = numpy.complex64(z)
+        x: numpy.float32 = (z).real
+        one: numpy.float32 = numpy.float32(1)
+        xp1: numpy.float32 = (x) + (one)
+        y: numpy.float32 = (z).imag
+        ay: numpy.float32 = numpy.abs(y)
+        axp1: numpy.float32 = numpy.abs(xp1)
+        mx: numpy.float32 = max(axp1, ay)
+        mn: numpy.float32 = min(axp1, ay)
+        r: numpy.float32 = (mn) / (mx)
+        result = make_complex(
+            (numpy.log1p((x) if ((xp1) >= (ay)) else ((mx) - (one))))
+            + ((numpy.float32(0.5)) * (numpy.log1p((one) if (numpy.equal(mn, mx, dtype=numpy.bool_)) else ((r) * (r))))),
+            numpy.arctan2(y, xp1),
+        )
+        return result
+
+
+def log1p_2(z: numpy.float64) -> numpy.float64:
+    with warnings.catch_warnings(action="ignore"):
+        z = numpy.float64(z)
+        result = numpy.log1p(z)
+        return result
+
+
+def log1p_3(z: numpy.float32) -> numpy.float32:
+    with warnings.catch_warnings(action="ignore"):
+        z = numpy.float32(z)
+        result = numpy.log1p(z)
+        return result

--- a/results/python/log1p.py
+++ b/results/python/log1p.py
@@ -1,0 +1,28 @@
+# This file is generated using functional_algorithms tool (0.4.0), see
+#   https://github.com/pearu/functional_algorithms
+# for more information.
+
+
+import math
+import sys
+
+
+def log1p_0(z: float) -> float:
+    return math.log1p(z)
+
+
+def log1p_1(z: complex) -> complex:
+    x: float = (z).real
+    one: float = 1
+    xp1: float = (x) + (one)
+    y: float = (z).imag
+    ay: float = abs(y)
+    axp1: float = abs(xp1)
+    mx: float = max(axp1, ay)
+    mn: float = min(axp1, ay)
+    r: float = (mn) / (mx)
+    return complex(
+        (math.log1p((x) if ((xp1) >= (ay)) else ((mx) - (one))))
+        + ((0.5) * (math.log1p((one) if ((mn) == (mx)) else ((r) * (r))))),
+        math.atan2(y, xp1),
+    )

--- a/results/stablehlo/log1p.td
+++ b/results/stablehlo/log1p.td
@@ -1,0 +1,43 @@
+// This file is generated using functional_algorithms tool (0.4.0), see
+//   https://github.com/pearu/functional_algorithms
+// for more information.
+
+
+
+
+def : Pat<(log1p_0 NonComplexElementType:$z),
+  (StableHLO_Log1pOp $z)>;
+
+def : Pat<(log1p_1 ComplexElementType:$z),
+  (StableHLO_ComplexOp
+    (StableHLO_AddOp
+      (StableHLO_Log1pOp
+        (StableHLO_SelectOp
+          (StableHLO_CompareOp
+           (StableHLO_AddOp:$xp1
+             (StableHLO_RealOp:$x $z),
+             (StableHLO_ConstantLike<"1">:$one $x)),
+           (StableHLO_AbsOp:$ay
+             (StableHLO_ImagOp:$y $z)),
+            StableHLO_ComparisonDirectionValue<"GE">,
+            (STABLEHLO_DEFAULT_COMPARISON_TYPE)),
+          $x,
+          (StableHLO_SubtractOp
+            (StableHLO_MaxOp:$mx
+              (StableHLO_AbsOp:$axp1 $xp1),
+              $ay),
+            $one))),
+      (StableHLO_MulOp
+        (StableHLO_ConstantLike<"0.5"> $x),
+        (StableHLO_Log1pOp
+          (StableHLO_SelectOp
+            (StableHLO_CompareOp
+             (StableHLO_MinOp:$mn $axp1, $ay),
+             $mx,
+              StableHLO_ComparisonDirectionValue<"EQ">,
+              (STABLEHLO_DEFAULT_COMPARISON_TYPE)),
+            $one,
+            (StableHLO_MulOp
+              (StableHLO_DivOp:$r $mn, $mx),
+              $r))))),
+    (StableHLO_Atan2Op $y, $xp1))>;

--- a/results/xla_client/complex_log1p.cc
+++ b/results/xla_client/complex_log1p.cc
@@ -1,0 +1,27 @@
+// This file is generated using functional_algorithms tool (0.4.0), see
+//   https://github.com/pearu/functional_algorithms
+// for more information.
+
+
+
+#include "xla/client/lib/constants.h"
+#include "xla/client/xla_builder.h"
+#include <limits>
+
+
+template <typename FloatType>
+XlaOp complex_log1p_0(XlaOp z) {
+  XlaOp x = Real(z);
+  XlaOp one = ScalarLike(x, 1);
+  XlaOp xp1 = Add(x, one);
+  XlaOp y = Imag(z);
+  XlaOp ay = Abs(y);
+  XlaOp axp1 = Abs(xp1);
+  XlaOp mx = Max(axp1, ay);
+  XlaOp mn = Min(axp1, ay);
+  XlaOp r = Div(mn, mx);
+  return Complex(
+      Add(Log1p(Select(Ge(xp1, ay), x, Sub(mx, one))),
+          Mul(ScalarLike(x, 0.5), Log1p(Select(Eq(mn, mx), one, Mul(r, r))))),
+      Atan2(y, xp1));
+}


### PR DESCRIPTION
As in the title.

TODO: improve the accuracy of log1p when `z.real` is close to `-0.5 * z.imag ** 2`.

RESOLUTION: For single precision, log1p variability around the above curve is very high - single ULP change in inputs results 100 or more ULP change in the output. In such cases, using ULP <= 3 as an accuracy check is not applicable. As a solution, this PR introduces another accuracy measure that checks if the result is within a range that is defined as a minimal region when varying inputs to reference by pre-specified ULP counts, typically 1.