### PR TITLE
Add upcast and downcast.

### DIFF
--- a/functional_algorithms/context.py
+++ b/functional_algorithms/context.py
@@ -203,8 +203,10 @@ class Context:
     # Python operator for naming conventions, logical operator names
     # use also CamelCase
 
-    def abs(self, x):
+    def absolute(self, x):
         return Expr(self, "abs", (x,))
+
+    abs = absolute
 
     def negative(self, x):
         return Expr(self, "negative", (x,))
@@ -426,3 +428,9 @@ class Context:
 
     def select(self, cond, x, y):
         return Expr(self, "select", (cond, x, y))
+
+    def upcast(self, x):
+        return Expr(self, "upcast", (x,))
+
+    def downcast(self, x):
+        return Expr(self, "downcast", (x,))

--- a/functional_algorithms/expr.py
+++ b/functional_algorithms/expr.py
@@ -706,4 +706,10 @@ class Expr:
             t = self.operands[0].get_type().max(self.operands[1].get_type())
             bits = t.bits * 2 if t.bits is not None else None
             return Type(self.context, "complex", bits)
+        elif self.kind == "upcast":
+            t = self.operands[0].get_type()
+            return Type(self.context, t.kind, t.bits * 2 if t.bits is not None else None)
+        elif self.kind == "downcast":
+            t = self.operands[0].get_type()
+            return Type(self.context, t.kind, t.bits // 2 if t.bits is not None else None)
         raise NotImplementedError((self.kind, str(self)))

--- a/functional_algorithms/rewrite.py
+++ b/functional_algorithms/rewrite.py
@@ -189,6 +189,12 @@ class Rewriter:
     def constant(self, expr):
         pass
 
+    def upcast(self, expr):
+        pass
+
+    def downcast(self, expr):
+        pass
+
     def log(self, expr):
         (x,) = expr.operands
         if x.kind == "constant":

--- a/functional_algorithms/targets/base.py
+++ b/functional_algorithms/targets/base.py
@@ -98,10 +98,13 @@ class PrinterBase:
                 raise NotImplementedError(
                     f"{type(self).__module__}.{type(self).__name__}.kind_to_target does not implement `{expr.kind}`"
                 )
-            m = dict()
-            for i in range(len(expr.operands)):
-                m["typeof_0"] = self.get_type(expr.operands[i])
-            result = tmpl.format(*[self.tostring(operand) for operand in expr.operands], **m)
+            if callable(tmpl):
+                result = tmpl(self, expr)
+            else:
+                m = dict()
+                for i in range(len(expr.operands)):
+                    m["typeof_0"] = self.get_type(expr.operands[i])
+                result = tmpl.format(*[self.tostring(operand) for operand in expr.operands], **m)
 
         assert expr.ref is not None
 

--- a/functional_algorithms/targets/numpy.py
+++ b/functional_algorithms/targets/numpy.py
@@ -24,6 +24,44 @@ def make_complex(r, i):
 )
 
 
+def upcast_func(target, expr):
+    assert expr.kind == "upcast", expr.kind
+    (x,) = expr.operands
+    t = target.get_type(x)
+    t_new = {
+        "numpy.float16": "numpy.float32",
+        "numpy.float32": "numpy.float64",
+        "numpy.float64": "numpy.float128",
+        "numpy.complex32": "numpy.complex64",
+        "numpy.complex64": "numpy.complex128",
+        "numpy.complex128": "numpy.complex256",
+        "numpy.int8": "numpy.int16",
+        "numpy.int16": "numpy.int32",
+        "numpy.int32": "numpy.int64",
+    }[t]
+    s = target.tostring(x)
+    return f"{t_new}({s})"
+
+
+def downcast_func(target, expr):
+    assert expr.kind == "downcast", expr.kind
+    (x,) = expr.operands
+    t = target.get_type(x)
+    t_new = {
+        "numpy.float32": "numpy.float16",
+        "numpy.float64": "numpy.float32",
+        "numpy.float128": "numpy.float64",
+        "numpy.complex64": "numpy.complex32",
+        "numpy.complex128": "numpy.complex64",
+        "numpy.complex256": "numpy.complex128",
+        "numpy.int16": "numpy.int8",
+        "numpy.int32": "numpy.int16",
+        "numpy.int64": "numpy.int32",
+    }[t]
+    s = target.tostring(x)
+    return f"{t_new}({s})"
+
+
 trace_arguments = dict(
     absolute=[(":complex128",), (":complex64",)],
     asin_acos_kernel=[(":complex128",), (":complex64",)],
@@ -110,6 +148,8 @@ kind_to_target = dict(
     eq="numpy.equal({0}, {1}, dtype=numpy.bool_)",
     ne="({0}) != ({1})",
     nextafter="numpy.nextafter({0}, {1})",
+    upcast=upcast_func,
+    downcast=downcast_func,
 )
 
 constant_to_target = dict(


### PR DESCRIPTION
As in the title.

In addition, this PR adds support for using custom functions in targets printer kind_to_target mapping.

`upcast` and `downcast` are mostly useful for testing how the accuracy of float32 native functions affects the accuracy of functions that use these native functions.

For instance, complex tan uses real tan/tanh functions and when applied to complex64 inputs. It turns out that the usage of upcasted real inputs to tan/tanh considerably improves the accuracy of complex64 tan. This proves that the native tan/tanh of float32 inputs are not accurate enough to guarantee the desired accuracy of complex64 tan/tanh.