### PR TITLE
Introduce definition decorator for algorithms

### DIFF
--- a/functional_algorithms/context.py
+++ b/functional_algorithms/context.py
@@ -39,6 +39,8 @@ class Context:
         self._default_constant_type = default_constant_type
         self._default_like = None
         self.parameters = parameters or {}
+        if "using" not in self.parameters:
+            self.parameters["using"] = set()
 
     @property
     def alt(self):

--- a/functional_algorithms/rewrite.py
+++ b/functional_algorithms/rewrite.py
@@ -121,6 +121,27 @@ class Rewriter:
     def atanh(self, expr):
         pass
 
+    def sin(self, expr):
+        pass
+
+    def sinh(self, expr):
+        pass
+
+    def cos(self, expr):
+        pass
+
+    def cosh(self, expr):
+        pass
+
+    def tan(self, expr):
+        pass
+
+    def tanh(self, expr):
+        pass
+
+    def exp(self, expr):
+        pass
+
     def _binary_op(self, expr, op):
         x, y = expr.operands
 

--- a/functional_algorithms/utils.py
+++ b/functional_algorithms/utils.py
@@ -1221,6 +1221,7 @@ def validate_function(
     workers=None,
     max_valid_ulp_count=3,
     max_bound_ulp_width=1,
+    bucket=None,
 ):
     fi = numpy.finfo(dtype)
     ulp_stats = defaultdict(int)
@@ -1241,6 +1242,10 @@ def validate_function(
         assert v1.dtype == v2.dtype, (sample, v1, v2)
         ulp = diff_ulp(v1, v2, flush_subnormals=flush_subnormals)
         ulp_stats[ulp] += 1
+
+        if bucket is not None:
+            # collect samples and values to a provide bucket
+            bucket.add(sample, ulp, v1, v2)
 
         if max_bound_ulp_width:
             within_bounds = is_within_bounds(v1, lower[index], upper[index])

--- a/results/README.md
+++ b/results/README.md
@@ -35,48 +35,62 @@ limit in general: there may exist function-function dependent regions
 in complex plane where `ulp_width` needs to be larger to pass the
 "out-of-ulp-range counts is zero" test.
 
+Finally, "using native <function?" means "using the corresponding
+numpy <function>".
 
-| Function | dtype | dULP=0 (exact) | dULP=1 | dULP=2 | dULP=3 | dULP>3 |
-| -------- | ----- | -------------- | ------ | ------ | ------ | ------ |
+| Function | dtype | dULP=0 (exact) | dULP=1 | dULP=2 | dULP=3 | dULP>3 | Notes |
+| -------- | ----- | -------------- | ------ | ------ | ------ | ------ | ----- |
 | absolute | complex64 | 967753 | 33696 | 552 | - | - |
+| absolute<sub>2</sub> | complex64 | 962185 | 39256 | 552 | - | 8 | using native absolute |
 | absolute | complex128 | 991753 | 10104 | 144 | - | - |
 | acos | float32 | 961608 | 38291 | 99 | 3 | - |
+| acos<sub>2</sub> | float32 | 961878 | 38119 | 4 | - | - | using native acos |
 | acos | float64 | 992582 | 7416 | 3 | - | - |
 | acos | complex64 | 810108 | 191263 | 622 | 8 | - |
+| acos<sub>2</sub> | complex64 | 678888 | 322829 | 284 | - | - | using native acos |
 | acos | complex128 | 690209 | 311554 | 238 | - | - |
 | acosh | float32 | 988269 | 11704 | 28 | - | - |
+| acosh<sub>2</sub> | float32 | 999248 | 753 | - | - | - | using native acosh |
 | acosh | float64 | 946246 | 53752 | 3 | - | - |
 | acosh | complex64 | 810108 | 191263 | 622 | 8 | - |
-| acosh | complex128 | 690209 | 311554 | 238 | - | - |
-| asin | float32 | 974679 | 24368 | 942 | 12 | - |
-| asin | float64 | 995197 | 4776 | 28 | - | - |
-| asin | complex64 | 807415 | 193174 | 1320 | 92 | - |
-| asin | complex128 | 687179 | 313978 | 844 | - | - |
-| asinh | float32 | 916129 | 83790 | 82 | - | - |
-| asinh | float64 | 825453 | 174482 | 66 | - | - |
-| asinh | complex64 | 807415 | 193174 | 1320 | 92 | - |
-| asinh | complex128 | 687179 | 313978 | 844 | - | - |
-| atan | float32 | 957469 | 42532 | - | - | - |
-| atan | float64 | 992077 | 7924 | - | - | - |
-| atan | complex64 | 903333 | 97028 | 1640 | - | - |
-| atan | complex128 | 957991 | 43914 | 96 | - | - |
-| atanh | float32 | 986261 | 13740 | - | - | - |
-| atanh | float64 | 995895 | 4106 | - | - | - |
-| atanh | complex64 | 850741 | 146392 | 4784 | 84 | - |
-| atanh | complex128 | 936337 | 65264 | 400 | - | - |
-| square | float32 | 997347 | 2654 | - | - | - |
-| square | float64 | 999593 | 408 | - | - | - |
-| square | complex64 | 976809 | 25192 | - | - | - |
-| square | complex128 | 995833 | 6168 | - | - | - |
-| sqrt | float32 | 1000001 | - | - | - | - |
-| sqrt | float64 | 1000001 | - | - | - | - |
-| sqrt | complex64 | 639749 | 362152 | 100 | - | - |
-| sqrt | complex128 | 653493 | 348492 | 16 | - | - |
-| angle | complex64 | 940281 | 61338 | 378 | 4 | - |
-| angle | complex128 | 989725 | 12276 | - | - | - |
-| log1p | float32 | 987438 | 12549 | 14 | - | - |
-| log1p | float64 | 945368 | 54622 | 11 | - | - |
-| log1p<sup>1</sup> | complex64 | 902287 | 97840<sup>47722</sup> | 1582<sup>1168</sup> | 102<sup>28</sup> | 190<sup>22</sup>!! |
-| log1p<sup>2</sup> | complex64 | 902287 | 97840<sup>42698</sup> | 1582<sup>72</sup> | 102<sup>6</sup> | 190<sup>2</sup>!! |
-| log1p<sup>3</sup> | complex64 | 902287 | 97840<sup>41454</sup> | 1582<sup>44</sup> | 102 | 190 |
-| log1p<sup>1</sup> | complex128 | 801864 | 200067<sup>188447</sup> | 64<sup>10</sup> | 6 | - |
+| acosh<sub>2</sub> | complex64 | 678888 | 322829 | 284 | - | - | using native acosh |
+| acosh | complex128 | 690209 | 311554 | 238 | - | - | - |
+| asin | float32 | 974679 | 24368 | 942 | 12 | - | - |
+| asin<sub>2</sub> | float32 | 996779 | 3010 | 212 | - | - | using native asin |
+| asin | float64 | 995197 | 4776 | 28 | - | - | - |
+| asin | complex64 | 807415 | 193174 | 1320 | 92 | - | - |
+| asin<sub>2</sub> | complex64 | 807661 | 194084 | 252 | 4 | - | using native asin |
+| asin | complex128 | 687179 | 313978 | 844 | - | - | - |
+| asinh | float32 | 916129 | 83790 | 82 | - | - | - |
+| asinh<sub>2</sub> | float32 | 999111 | 890 | - | - | - | using native asinh |
+| asinh | float64 | 825453 | 174482 | 66 | - | - | - |
+| asinh | complex64 | 807415 | 193174 | 1320 | 92 | - | - |
+| asinh<sub>2</sub> | complex64 | 807661 | 194084 | 252 | 4 | - | using native asinh |
+| asinh | complex128 | 687179 | 313978 | 844 | - | - | - |
+| atan | complex64 | 850741 | 146392 | 4784 | 84 | - | - |
+| atan<sub>2</sub> | complex64 | 903333 | 97028 | 1640 | - | - | using native atan |
+| atan | complex128 | 936337 | 65264 | 400 | - | - | - |
+| atanh | complex64 | 850741 | 146392 | 4784 | 84 | - | - |
+| atanh<sub>2</sub> | complex64 | 903333 | 97028 | 1640 | - | - | using native atanh |
+| atanh | complex128 | 936337 | 65264 | 400 | - | - | - |
+| square | float32 | 997347 | 2654 | - | - | - | - |
+| square<sub>2</sub> | float32 | 997347 | 2654 | - | - | - | using native square |
+| square | float64 | 999593 | 408 | - | - | - | - |
+| square | complex64 | 976809 | 25192 | - | - | - | - |
+| square<sub>2</sub> | complex64 | 939997 | 29016 | 16 | - | 32972 | using native square |
+| square | complex128 | 995833 | 6168 | - | - | - | - |
+| sqrt | float32 | 1000001 | - | - | - | - | using native sqrt |
+| sqrt | complex64 | 639749 | 362152 | 100 | - | - | using native sqrt |
+| angle | complex64 | 940281 | 61338 | 378 | 4 | - | - |
+| angle | complex128 | 989725 | 12276 | - | - | - | - |
+| log1p<sup>1</sup> | complex64 | 697224 | 62971<sup>50269</sup> | 2437<sup>1108</sup> | 1521<sup>1505</sup> | 237848<sup>237612</sup>!! | using native log1p |
+| log1p<sup>2</sup> | complex64 | 902287 | 97840<sup>42698</sup> | 1582<sup>72</sup> | 102<sup>6</sup> | 190<sup>2</sup>!! | - |
+| log1p<sup>3</sup> | complex64 | 902287 | 97840<sup>41454</sup> | 1582<sup>44</sup> | 102 | 190 | - |
+| log1p<sup>1</sup> | complex64 | 697224 | 62971<sup>50269</sup> | 2437<sup>1108</sup> | 1521<sup>1505</sup> | 237848<sup>237612</sup>!! | using native log1p |
+| log1p<sup>2</sup> | complex64 | 902287 | 97840<sup>42698</sup> | 1582<sup>72</sup> | 102<sup>6</sup> | 190<sup>2</sup>!! | - |
+| log1p<sup>3</sup> | complex64 | 902287 | 97840<sup>41454</sup> | 1582<sup>44</sup> | 102 | 190 | - |
+| log1p<sup>1</sup> | complex128 | 801864 | 200067<sup>188447</sup> | 64<sup>10</sup> | 6 | - | - |
+| tan | float32 | 866723 | 132062 | 1168 | 48 | - | using native tan |
+| tan | complex64 | 817727 | 159602 | 21188 | 2958 | 526 | using upcast tan |
+| tanh | float32 | 985109 | 14892 | - | - | - | using native tanh |
+| tanh | complex64 | 779679 | 197584 | 19902 | 776 | 4060 | using native tanh |


### PR DESCRIPTION
As in the title.

The `definition` decorator defines the API for defining algorithms.

In addition, the PR introduces `use_native_<function>` context parameter than enables switching between the native implementation of the function and the one provided in algorithms.py.