### PR TITLE
Introduce use_upcast_<function> context parameter. Add native tan/tanh.

### DIFF
--- a/functional_algorithms/expr.py
+++ b/functional_algorithms/expr.py
@@ -304,7 +304,10 @@ class Expr:
                 paths = ":".join([m.__name__ for m in self.context._paths])
                 raise NotImplementedError(f'{self.kind} for {target.__name__.split(".")[-1]} target [paths={paths}]')
 
-            result = self.context.call(func, self.operands).implement_missing(target)
+            result = self.context.call(func, self.operands)
+            if self._serialized == result._serialized:
+                return self
+            result = result.implement_missing(target)
         else:
             operands = tuple([operand.implement_missing(target) for operand in self.operands])
             for o1, o2 in zip(operands, self.operands):

--- a/functional_algorithms/tests/test_algorithms.py
+++ b/functional_algorithms/tests/test_algorithms.py
@@ -18,7 +18,7 @@ def dtype_name(request):
 
 @pytest.fixture(
     scope="function",
-    params=["absolute", "acos", "acosh", "asin", "asinh", "hypot", "square", "sqrt", "angle", "atan", "atanh"],
+    params=["absolute", "acos", "acosh", "asin", "asinh", "hypot", "square", "sqrt", "angle", "atan", "atanh", "tan", "tanh"],
 )
 def func_name(request):
     return request.param
@@ -26,7 +26,7 @@ def func_name(request):
 
 @pytest.fixture(
     scope="function",
-    params=["absolute", "acos", "acosh", "asin", "asinh", "square", "sqrt", "angle", "log1p", "atan", "atanh"],
+    params=["absolute", "acos", "acosh", "asin", "asinh", "square", "sqrt", "angle", "log1p", "atan", "atanh", "tan", "tanh"],
 )
 def unary_func_name(request):
     return request.param

--- a/functional_algorithms/utils.py
+++ b/functional_algorithms/utils.py
@@ -395,7 +395,7 @@ class mpmath_array_api:
                     return ctx.make_mpc((ctx.one._mpf_, ctx.zero._mpf_))
                 return ctx.make_mpc(((-ctx.one)._mpf_, ctx.zero._mpf_))
             elif ctx.isnan(x.real):
-                if y.imag == 0:
+                if x.imag == 0:
                     return ctx.make_mpc((ctx.nan._mpf_, ctx.zero._mpf_))
                 return ctx.make_mpc((ctx.nan._mpf_, ctx.nan._mpf_))
 

--- a/results/README.md
+++ b/results/README.md
@@ -35,8 +35,11 @@ limit in general: there may exist function-function dependent regions
 in complex plane where `ulp_width` needs to be larger to pass the
 "out-of-ulp-range counts is zero" test.
 
-Finally, "using native <function?" means "using the corresponding
-numpy <function>".
+Finally,
+- "using native <function>" means "using the corresponding numpy <function>",
+- "using upcast <function>" means that the function arguments are
+  upcasted to a dtype with bits doubled, and the function results are
+  downcasted to a dtype with bits split half.
 
 | Function | dtype | dULP=0 (exact) | dULP=1 | dULP=2 | dULP=3 | dULP>3 | Notes |
 | -------- | ----- | -------------- | ------ | ------ | ------ | ------ | ----- |
@@ -91,6 +94,10 @@ numpy <function>".
 | log1p<sup>3</sup> | complex64 | 902287 | 97840<sup>41454</sup> | 1582<sup>44</sup> | 102 | 190 | - |
 | log1p<sup>1</sup> | complex128 | 801864 | 200067<sup>188447</sup> | 64<sup>10</sup> | 6 | - | - |
 | tan | float32 | 866723 | 132062 | 1168 | 48 | - | using native tan |
-| tan | complex64 | 817727 | 159602 | 21188 | 2958 | 526 | using upcast tan |
+| tan<sub>2</sub> | float32 | 1000001 | - | - | - | - | using upcast tan, native tan |
+| tan | complex64 | 783679 | 197584 | 19902 | 776 | 60 | using native tan |
+| tan<sub>2</sub> | complex64 | 1001417 | 584 | - | - | - | using upcast tan, native tan |
 | tanh | float32 | 985109 | 14892 | - | - | - | using native tanh |
-| tanh | complex64 | 779679 | 197584 | 19902 | 776 | 4060 | using native tanh |
+| tanh<sub>2</sub> | float32 | 1000001 | - | - | - | - | using native tanh, upcast tanh |
+| tanh | complex64 | 783679 | 197584 | 19902 | 776 | 60 | using native tanh |
+| tanh<sub>2</sub> | complex64 | 1001417 | 584 | - | - | - | using native tanh, upcast tanh |

--- a/results/estimate_accuracy.py
+++ b/results/estimate_accuracy.py
@@ -94,16 +94,19 @@ def get_inputs():
         ("log1p", np.complex128, {}),
         # ("tan", np.float32, dict()),  # real_tan is not implemented
         ("tan", np.float32, dict(use_native_tan=True)),
-        # ("tan", np.float32, dict(use_upcast_tan=True)),
+        ("tan", np.float32, dict(use_native_tan=True, use_upcast_tan=True)),
         # ("tan", np.float64, {}),  # real_tan is not implemented
         # ("tan", np.complex64, {}),  # tan is not implemented
         ("tan", np.complex64, dict(use_native_tan=True)),
+        ("tan", np.complex64, dict(use_native_tan=True, use_upcast_tan=True)),
         # ("tan", np.complex128, {}),  # tan is not implemented
         ("tanh", np.float32, dict(use_native_tanh=True)),
+        ("tanh", np.float32, dict(use_native_tanh=True, use_upcast_tanh=True)),
         # ("tanh", np.float64, {}),  # real_tanh is not implemented
         # ("tanh", np.complex64, {}),  # tanh is not implemented
         # ("tanh", np.complex64, dict(use_upcast_tan=True, use_upcast_tanh=True, use_upcast_cos=True)),
         ("tanh", np.complex64, dict(use_native_tanh=True)),
+        ("tanh", np.complex64, dict(use_native_tanh=True, use_upcast_tanh=True)),
         # ("tanh", np.complex128, {}),  # tanh is not implemented
     ]:
         validation_parameters = fa.utils.function_validation_parameters(func_name, dtype)
@@ -190,8 +193,11 @@ limit in general: there may exist function-function dependent regions
 in complex plane where `ulp_width` needs to be larger to pass the
 "out-of-ulp-range counts is zero" test.
 
-Finally, "using native <function?" means "using the corresponding
-numpy <function>".
+Finally,
+- "using native <function>" means "using the corresponding numpy <function>",
+- "using upcast <function>" means that the function arguments are
+  upcasted to a dtype with bits doubled, and the function results are
+  downcasted to a dtype with bits split half.
 """,
         file=f,
     )


### PR DESCRIPTION
As in the title.

With `use_upcast_<function>=True`, the calls to function are preprocessed by upcasting arguments and postprocessed by downcasting results.