### PR TITLE
Revise rewrite methods.

### DIFF
--- a/functional_algorithms/__init__.py
+++ b/functional_algorithms/__init__.py
@@ -16,3 +16,4 @@ from .context import Context
 from . import algorithms
 from . import targets
 from .textimage import TextImage
+from . import rewrite

--- a/functional_algorithms/rewrite.py
+++ b/functional_algorithms/rewrite.py
@@ -211,10 +211,14 @@ class Rewriter:
         pass
 
     def upcast(self, expr):
-        pass
+        (x,) = expr.operands
+        if x.kind == "downcast":
+            return x.operands[0]
 
     def downcast(self, expr):
-        pass
+        (x,) = expr.operands
+        if x.kind == "upcast":
+            return x.operands[0]
 
     def log(self, expr):
         (x,) = expr.operands
@@ -403,3 +407,8 @@ def rewrite(expr):
             break
 
     return last_result
+
+
+def __rewrite_modifier__(expr):
+    result = rewrite(expr)
+    return expr if result is None else result

--- a/functional_algorithms/targets/cpp.py
+++ b/functional_algorithms/targets/cpp.py
@@ -1,7 +1,7 @@
 import warnings
 
-from . import xla_client as this_module
-from .base import PrinterBase
+from . import cpp as this_module
+from .base import PrinterBase, modifier_base
 from .. import utils
 
 constant_target = this_module
@@ -33,6 +33,10 @@ trace_arguments = dict(
 )
 
 source_file_extension = ".cpp"
+
+
+def __rewrite_modifier__(expr):
+    return modifier_base(this_module, expr)
 
 
 def make_comment(message):

--- a/functional_algorithms/targets/numpy.py
+++ b/functional_algorithms/targets/numpy.py
@@ -5,7 +5,8 @@ import warnings
 
 from .. import utils
 from . import numpy as this_module
-from .base import PrinterBase
+from .base import PrinterBase, modifier_base
+
 
 constant_target = this_module
 
@@ -22,6 +23,10 @@ def make_complex(r, i):
   raise NotImplementedError((r.dtype, i.dtype))
 """
 )
+
+
+def __rewrite_modifier__(expr):
+    return modifier_base(this_module, expr)
 
 
 def upcast_func(target, expr):
@@ -138,7 +143,7 @@ kind_to_target = dict(
     imag="({0}).imag",
     complex="make_complex({0}, {1})",
     hypot=NotImplemented,
-    square=NotImplemented,
+    square="numpy.square({0})",
     sqrt="numpy.sqrt({0})",
     select="({1}) if ({0}) else ({2})",
     lt="({0}) < ({1})",
@@ -170,6 +175,7 @@ type_to_target = dict(
     float32="numpy.float32",
     float64="numpy.float64",
     float="numpy.float64",
+    float128="numpy.float128",
     complex64="numpy.complex64",
     complex128="numpy.complex128",
     complex="numpy.complex128",

--- a/functional_algorithms/targets/python.py
+++ b/functional_algorithms/targets/python.py
@@ -3,7 +3,7 @@ import sys
 import math
 from . import python as this_module
 from .. import utils
-from .base import PrinterBase
+from .base import PrinterBase, modifier_base
 
 constant_target = this_module
 
@@ -13,6 +13,10 @@ import math
 import sys
 """
 )
+
+
+def __rewrite_modifier__(expr):
+    return modifier_base(this_module, expr)
 
 
 trace_arguments = dict(

--- a/functional_algorithms/targets/stablehlo.py
+++ b/functional_algorithms/targets/stablehlo.py
@@ -2,6 +2,7 @@ import warnings
 
 from . import stablehlo as this_module
 from ..expr import Expr
+from .base import modifier_base
 
 constant_target = this_module
 
@@ -24,6 +25,10 @@ trace_arguments = dict(
 
 
 source_file_extension = ".td"
+
+
+def __rewrite_modifier__(expr):
+    return modifier_base(this_module, expr)
 
 
 def make_comment(message):

--- a/functional_algorithms/targets/xla_client.py
+++ b/functional_algorithms/targets/xla_client.py
@@ -2,7 +2,7 @@ import warnings
 
 from . import xla_client as this_module
 from . import cpp as constant_target
-from .base import PrinterBase
+from .base import PrinterBase, modifier_base
 from .. import utils
 
 source_file_header = """
@@ -34,6 +34,10 @@ trace_arguments = dict(
 )
 
 source_file_extension = ".cc"
+
+
+def __rewrite_modifier__(expr):
+    return modifier_base(this_module, expr)
 
 
 def make_comment(message):

--- a/functional_algorithms/tests/test_algorithms.py
+++ b/functional_algorithms/tests/test_algorithms.py
@@ -2,7 +2,7 @@ import inspect
 import numpy
 import math
 import cmath
-from functional_algorithms import Context, targets, algorithms, utils
+from functional_algorithms import Context, targets, algorithms, utils, rewrite
 import pytest
 
 
@@ -54,7 +54,7 @@ def test_unary(dtype_name, unary_func_name, flush_subnormals):
     except NotImplementedError as msg:
         pytest.skip(reason=str(msg))
 
-    graph2 = graph.implement_missing(targets.numpy).simplify()
+    graph2 = graph.rewrite(targets.numpy, rewrite)
 
     func = targets.numpy.as_function(graph2, debug=0)
 
@@ -136,7 +136,7 @@ def test_binary(dtype_name, binary_func_name, flush_subnormals):
 
     graph = ctx.trace(getattr(algorithms, binary_func_name), dtype, dtype)
 
-    graph2 = graph.implement_missing(targets.numpy).simplify()
+    graph2 = graph.rewrite(targets.numpy, rewrite)
     func = targets.numpy.as_function(graph2, debug=1)
     reference = getattr(utils.numpy_with_mpmath(extra_prec_multiplier=10, flush_subnormals=flush_subnormals), binary_func_name)
 
@@ -161,7 +161,7 @@ def test_target(func_name, target_name):
     target = getattr(targets, target_name)
     ctx = Context(paths=[algorithms], enable_alt=dict(xla_client=True).get(target_name, False), default_constant_type="DType2")
     try:
-        graph = ctx.trace(getattr(algorithms, func_name)).implement_missing(target).simplify()
+        graph = ctx.trace(getattr(algorithms, func_name)).rewrite(target, rewrite)
     except NotImplementedError as msg:
         pytest.skip(reason=str(msg))
     src = graph.tostring(target)

--- a/results/README.md
+++ b/results/README.md
@@ -43,19 +43,19 @@ Finally,
 
 | Function | dtype | dULP=0 (exact) | dULP=1 | dULP=2 | dULP=3 | dULP>3 | Notes |
 | -------- | ----- | -------------- | ------ | ------ | ------ | ------ | ----- |
-| absolute | complex64 | 967753 | 33696 | 552 | - | - |
+| absolute | complex64 | 967753 | 33696 | 552 | - | - | - |
 | absolute<sub>2</sub> | complex64 | 962185 | 39256 | 552 | - | 8 | using native absolute |
-| absolute | complex128 | 991753 | 10104 | 144 | - | - |
-| acos | float32 | 961608 | 38291 | 99 | 3 | - |
+| absolute | complex128 | 991753 | 10104 | 144 | - | - | - |
+| acos | float32 | 961608 | 38291 | 99 | 3 | - | - |
 | acos<sub>2</sub> | float32 | 961878 | 38119 | 4 | - | - | using native acos |
-| acos | float64 | 992582 | 7416 | 3 | - | - |
-| acos | complex64 | 810108 | 191263 | 622 | 8 | - |
+| acos | float64 | 992582 | 7416 | 3 | - | - | - |
+| acos | complex64 | 810108 | 191263 | 622 | 8 | - | - |
 | acos<sub>2</sub> | complex64 | 678888 | 322829 | 284 | - | - | using native acos |
-| acos | complex128 | 690209 | 311554 | 238 | - | - |
-| acosh | float32 | 988269 | 11704 | 28 | - | - |
+| acos | complex128 | 690209 | 311554 | 238 | - | - | - |
+| acosh | float32 | 988269 | 11704 | 28 | - | - | - |
 | acosh<sub>2</sub> | float32 | 999248 | 753 | - | - | - | using native acosh |
-| acosh | float64 | 946246 | 53752 | 3 | - | - |
-| acosh | complex64 | 810108 | 191263 | 622 | 8 | - |
+| acosh | float64 | 946246 | 53752 | 3 | - | - | - |
+| acosh | complex64 | 810108 | 191263 | 622 | 8 | - | - |
 | acosh<sub>2</sub> | complex64 | 678888 | 322829 | 284 | - | - | using native acosh |
 | acosh | complex128 | 690209 | 311554 | 238 | - | - | - |
 | asin | float32 | 974679 | 24368 | 942 | 12 | - | - |
@@ -86,18 +86,20 @@ Finally,
 | sqrt | complex64 | 639749 | 362152 | 100 | - | - | using native sqrt |
 | angle | complex64 | 940281 | 61338 | 378 | 4 | - | - |
 | angle | complex128 | 989725 | 12276 | - | - | - | - |
-| log1p<sup>1</sup> | complex64 | 697224 | 62971<sup>50269</sup> | 2437<sup>1108</sup> | 1521<sup>1505</sup> | 237848<sup>237612</sup>!! | using native log1p |
+| log1p<sup>1</sup> | complex64 | 902287 | 97840<sup>47722</sup> | 1582<sup>1168</sup> | 102<sup>28</sup> | 190<sup>22</sup>!! | - |
 | log1p<sup>2</sup> | complex64 | 902287 | 97840<sup>42698</sup> | 1582<sup>72</sup> | 102<sup>6</sup> | 190<sup>2</sup>!! | - |
 | log1p<sup>3</sup> | complex64 | 902287 | 97840<sup>41454</sup> | 1582<sup>44</sup> | 102 | 190 | - |
 | log1p<sup>1</sup> | complex64 | 697224 | 62971<sup>50269</sup> | 2437<sup>1108</sup> | 1521<sup>1505</sup> | 237848<sup>237612</sup>!! | using native log1p |
-| log1p<sup>2</sup> | complex64 | 902287 | 97840<sup>42698</sup> | 1582<sup>72</sup> | 102<sup>6</sup> | 190<sup>2</sup>!! | - |
-| log1p<sup>3</sup> | complex64 | 902287 | 97840<sup>41454</sup> | 1582<sup>44</sup> | 102 | 190 | - |
+| log1p<sup>2</sup>[using={'native log1p'}] | complex64 | 697224 | 62971<sup>49386</sup> | 2437<sup>48</sup> | 1521<sup>984</sup> | 237848<sup>237376</sup>!! | using native log1p |
+| log1p<sup>3</sup>[using={'native log1p'}] | complex64 | 697224 | 62971<sup>49206</sup> | 2437<sup>8</sup> | 1521<sup>36</sup> | 237848<sup>235730</sup>!! | using native log1p |
 | log1p<sup>1</sup> | complex128 | 801864 | 200067<sup>188447</sup> | 64<sup>10</sup> | 6 | - | - |
 | tan | float32 | 866723 | 132062 | 1168 | 48 | - | using native tan |
-| tan<sub>2</sub> | float32 | 1000001 | - | - | - | - | using upcast tan, native tan |
+| tan<sub>2</sub> | float32 | 1000001 | - | - | - | - | using native tan, upcast tan |
 | tan | complex64 | 783679 | 197584 | 19902 | 776 | 60 | using native tan |
-| tan<sub>2</sub> | complex64 | 1001417 | 584 | - | - | - | using upcast tan, native tan |
+| tan<sub>2</sub> | complex64 | 1001417 | 584 | - | - | - | using native tan, upcast tan |
 | tanh | float32 | 985109 | 14892 | - | - | - | using native tanh |
 | tanh<sub>2</sub> | float32 | 1000001 | - | - | - | - | using native tanh, upcast tanh |
 | tanh | complex64 | 783679 | 197584 | 19902 | 776 | 60 | using native tanh |
 | tanh<sub>2</sub> | complex64 | 1001417 | 584 | - | - | - | using native tanh, upcast tanh |
+| real_naive_tan | float32 | 819251 | 179168 | 1580 | 2 | - | - |
+| real_naive_tan<sub>2</sub> | float32 | 825895 | 173622 | 484 | - | - | using upcast cos, upcast sin |


### PR DESCRIPTION
This PR eliminates `simplify` and `implement_missing` methods in favor of revised `rewrite` method. The revised `rewrite` takes one or more modifier arguments that are applied to expressions and that are simple callable objects with specific rewrite rules.