### PR TITLE
Add JAX backend support.

### DIFF
--- a/functional_algorithms/__init__.py
+++ b/functional_algorithms/__init__.py
@@ -17,3 +17,4 @@ from . import algorithms
 from . import targets
 from .textimage import TextImage
 from . import rewrite
+from .signatures import filter_signatures

--- a/functional_algorithms/signatures.py
+++ b/functional_algorithms/signatures.py
@@ -1,0 +1,108 @@
+"""Provides signatures of math functions.
+"""
+
+
+def all_signatures():
+    yield from _signature_iter(_array_api_element_wise_functions)
+
+
+def filter_signatures(atypes="C", rtypes="C"):
+    atypes = tuple(atypes)
+    rtypes = tuple(rtypes)
+    for sig in all_signatures():
+        if sig["atypes"] == atypes and sig["rtypes"] == rtypes:
+            yield sig
+
+
+def _signature_iter(text):
+    for line in text.splitlines():
+        line = line.strip()
+        if line.startswith("#") or not line:
+            continue
+        left, rtype = line.split("->", 1)
+        rtypes = tuple(r.strip() for r in rtype.strip().split(","))
+        name = line[: line.find("(")].strip()
+        atypes = []
+        anames = []
+        for arg in left.rstrip()[left.find("(") + 1 : -1].split(","):
+            arg = arg.strip()
+            if arg == "/":
+                break
+            atype, aname = arg.split()
+            atype = atype.strip()
+            aname = aname.strip()
+            atypes.append(atype)
+            anames.append(anames)
+        yield dict(name=name, atypes=tuple(atypes), anames=tuple(anames), rtypes=rtypes)
+
+
+_array_api_element_wise_functions = """
+abs(F x, /) -> F
+abs(C x, /) -> F
+acos(F x, /) -> F
+acos(C x, /) -> C
+acosh(F x, /) -> F
+acosh(C x, /) -> C
+add(F x1, F x2, /) -> F
+add(C x1, C x2, /) -> C
+add(F x1, C x2, /) -> C
+add(C x1, V x2, /) -> C
+asin(F x, /) -> F
+asin(C x, /) -> C
+asinh(F x, /) -> F
+asinh(C x, /) -> C
+atan(F x, /) -> F
+atan(C x, /) -> C
+atan2(F x1, F x2, /) -> F
+atanh(F x, /) -> F
+atanh(C x, /) -> C
+conj(C x, /) -> C
+cos(F x, /) -> F
+cos(C x, /) -> C
+cosh(F x, /) -> F
+cosh(C x, /) -> C
+exp(F x, /) -> F
+exp(C x, /) -> C
+expm1(F x, /) -> F
+expm1(C x, /) -> C
+hypot(F x1, F x2, /) -> F
+imag(C x, /) -> F
+log(F x, /) -> F
+log(C x, /) -> C
+log1p(F x, /) -> F
+log1p(C x, /) -> C
+log2(F x, /) -> F
+log2(C x, /) -> C
+log10(F x, /) -> F
+log10(C x, /) -> C
+logaddexp(F x1, F x2, /) -> F
+multiply(F x1, F x2, /) -> F
+multiply(C x1, C x2, /) -> C
+multiply(F x1, C x2, /) -> C
+multiply(C x1, F x2, /) -> C
+negative(F x, /) -> F
+negative(C x, /) -> C
+positive(F x, /) -> F
+positive(C x, /) -> C
+pow(F x1, F x2, /) -> F
+pow(C x1, C x2, /) -> C
+pow(C x1, F x2, /) -> C
+pow(F x1, C x2, /) -> C
+real(C x, /) -> F
+sin(F x, /) -> F
+sin(C x, /) -> C
+sinh(F x, /) -> F
+sinh(C x, /) -> C
+square(F x, /) -> F
+square(C x, /) -> C
+sqrt(F x, /) -> F
+sqrt(C x, /) -> C
+subtract(F x1, F x2, /) -> F
+subtract(C x1, C x2, /) -> C
+subtract(F x1, C x2, /) -> C
+subtract(C x1, V x2, /) -> C
+tan(F x, /) -> F
+tan(C x, /) -> C
+tanh(F x, /) -> F
+tanh(C x, /) -> C
+"""

--- a/functional_algorithms/targets/numpy.py
+++ b/functional_algorithms/targets/numpy.py
@@ -1,4 +1,3 @@
-import black
 import numpy
 import sys
 import warnings

--- a/functional_algorithms/tests/test_accuracy.py
+++ b/functional_algorithms/tests/test_accuracy.py
@@ -1,0 +1,155 @@
+import numpy
+import functional_algorithms as fa
+import pytest
+import warnings
+
+
+@pytest.fixture(scope="function", params=["jax"])
+def backend(request):
+    return request.param
+
+
+@pytest.fixture(scope="function", params=["cpu", "cuda"])
+def device(request):
+    return request.param
+
+
+@pytest.fixture(scope="function", params=list(sig["name"] for sig in fa.filter_signatures("C", "C")))
+def unary_func_name(request):
+    return request.param
+
+
+@pytest.fixture(scope="function", params=[numpy.float32, numpy.float64, numpy.complex64, numpy.complex128])
+def dtype(request):
+    return request.param
+
+
+def test_unary(unary_func_name, backend, device, dtype):
+    pytest.importorskip(backend)
+
+    func = getattr(getattr(fa.utils, f"numpy_with_{backend}")(device=device), unary_func_name)
+
+    if not func.backend_is_available(device):
+        pytest.skip(f"{device} support is unavailable")
+    params = fa.utils.function_validation_parameters(unary_func_name, dtype)
+
+    max_valid_ulp_count = params["max_valid_ulp_count"]
+    extra_prec_multiplier = params["extra_prec_multiplier"]
+    samples_limits = params["samples_limits"]
+    include_subnormal = True
+
+    mpmath = fa.utils.numpy_with_mpmath(extra_prec_multiplier=extra_prec_multiplier)
+
+    reference = getattr(mpmath, unary_func_name)
+    npy_reference = getattr(fa.utils.numpy_with_numpy(), unary_func_name)
+
+    re_blocks, im_blocks = 101, 51
+    re_blocksize, im_blocksize = 20, 20
+    re_size, im_size = re_blocks * re_blocksize, im_blocks * im_blocksize
+
+    if dtype in {numpy.complex64, numpy.complex128}:
+        samples = fa.utils.complex_samples(
+            (re_size, im_size), dtype=dtype, include_subnormal=include_subnormal, **samples_limits
+        )
+    else:
+        pytest.skip(f"{dtype} support not implemented")
+    assert samples.shape == (im_size, re_size)
+
+    expected = reference.call(samples)
+    result = func(samples)
+
+    ulp = fa.utils.diff_ulp(result, expected, flush_subnormals=not include_subnormal)
+
+    if numpy.all(ulp == 0):
+        return
+    if numpy.all(ulp <= max_valid_ulp_count):
+        print(f"maximal ULP difference: {ulp.max()}")
+        return
+
+    bsamples = numpy.zeros((im_blocks, re_blocks), dtype=samples.dtype)
+    bulp = numpy.zeros((im_blocks, re_blocks), dtype=ulp.dtype)
+    for j, blocks in enumerate(numpy.split(ulp, im_blocks, axis=0)):
+        for i, block in enumerate(numpy.split(blocks, re_blocks, axis=1)):
+            ind = numpy.unravel_index(numpy.argmax(block, axis=None), block.shape)
+            j_, i_ = j * im_blocksize + ind[0], i * re_blocksize + ind[1]
+            bsamples[j, i] = samples[j_, i_]
+            bulp[j, i] = ulp[j_, i_]
+
+    try:
+        fa_reference = getattr(fa.utils.numpy_with_algorithms(dtype=dtype), unary_func_name)
+    except Exception as msg:
+        print(f"disabling functional_algorithms output: {msg}")
+        fa_reference = None
+
+    timage = fa.TextImage()
+
+    timage.fill(0, 10, bulp == 0, symbol="=")
+    for i in range(1, max_valid_ulp_count + 1):
+        timage.fill(0, 10, bulp == i, symbol=str(i))
+
+    timage.fill(0, 10, bulp > max_valid_ulp_count, symbol="!")
+    timage.fill(0, 10, bulp > 100 * max_valid_ulp_count, symbol="E")
+
+    real_axis = samples[0:1, ::im_blocksize].real
+    imag_axis = samples[::re_blocksize, 0:1].imag
+    timage.insert(0, 2, fa.TextImage.fromseq(imag_axis))
+    timage.append(-1, 10, fa.TextImage.fromseq(real_axis[:, ::6], mintextwidth=5, maxtextwidth=5))
+
+    print()
+    print(timage)
+    print()
+
+    if fa_reference is not None:
+        rows = [
+            (
+                "ULP-difference",
+                "z",
+                f"{backend}:{unary_func_name}(z)",
+                f"mpmath:{unary_func_name}(z)",
+                f"numpy:{unary_func_name}(z)",
+                f"fa:{unary_func_name}(z)",
+            )
+        ]
+    else:
+        rows = [
+            (
+                "ULP-difference",
+                "z",
+                f"{backend}:{unary_func_name}(z)",
+                f"mpmath:{unary_func_name}(z)",
+                f"numpy:{unary_func_name}(z)",
+            )
+        ]
+
+    samples = bsamples
+    ulp = bulp
+
+    max_rows = 20
+    for value in reversed(sorted(set(ulp.flatten()))):
+        if value <= max_valid_ulp_count:
+            break
+        clusters = fa.utils.Clusters()
+        for re, im in zip(*numpy.where(ulp == value)):
+            clusters.add((re, im))
+        for cluster in clusters:
+            re, im = cluster.center_point()
+            with warnings.catch_warnings(action="ignore"):
+                np_value = npy_reference(samples[re, im])
+            r = func(samples[re, im])
+            e = reference(samples[re, im])
+            if fa_reference is not None:
+                fa_value = fa_reference(samples[re, im])
+                rows.append((value, samples[re, im], r, e, np_value, fa_value))
+            else:
+                rows.append((value, samples[re, im], r, e, np_value))
+            if len(rows) > max_rows:
+                break
+        if len(rows) > max_rows:
+            rows.append(("...",) * len(rows[0]))
+            break
+    col_widths = [max(len(str(row[col])) for row in rows) for col in range(len(rows[0]))]
+    rows.insert(1, tuple("-" * w for w in col_widths))
+    col_fmt = "| " + " | ".join([f"{{{i}:>{w}}}" for i, w in enumerate(col_widths)]) + " |"
+    print("\n".join([col_fmt.format(*map(str, row)) for row in rows]))
+
+    pytest.xfail("inaccurate or incorrect results")

--- a/functional_algorithms/tests/test_functional_algorithms.py
+++ b/functional_algorithms/tests/test_functional_algorithms.py
@@ -240,16 +240,16 @@ def test_readme_square_numpy_debug_0():
     assert py == utils.format_python(
         """\
 def readme_square(z: numpy.complex128) -> numpy.complex128:
-    with warnings.catch_warnings(action="ignore"):
-        z = numpy.complex128(z)
-        real_z: numpy.float64 = (z).real
-        x: numpy.float64 = numpy.abs(real_z)
-        y: numpy.float64 = numpy.abs((z).imag)
-        real_part: numpy.float64 = ((x) - (y)) * ((y) + (y))
-        real: numpy.float64 = (numpy.float64(0)) if (numpy.equal(x, y, dtype=numpy.bool_)) else (real_part)
-        imag: numpy.float64 = (numpy.float64(2)) * ((x) * (y))
-        result = make_complex(real, imag)
-        return result"""
+  with warnings.catch_warnings(action="ignore"):
+    z = numpy.complex128(z)
+    real_z: numpy.float64 = (z).real
+    x: numpy.float64 = numpy.abs(real_z)
+    y: numpy.float64 = numpy.abs((z).imag)
+    real_part: numpy.float64 = ((x) - (y)) * ((y) + (y))
+    real: numpy.float64 = (numpy.float64(0)) if (numpy.equal(x, y, dtype=numpy.bool_)) else (real_part)
+    imag: numpy.float64 = (numpy.float64(2)) * ((x) * (y))
+    result = make_complex(real, imag)
+    return result"""
     )
 
 


### PR DESCRIPTION
As in the title:

- add `vectorize_with_jax` that is equivalent to `numpy.vectorize` but the function evaluation is carried out using JAX arrays.
- add `numpy_with_jax` that is equivalent to `numpy` as a namespace but function evaluations are carried out using JAX arrays.
- similarly, add `numpy_with_algorithms` and `numpy_with_numpy`
- add `signatures` module holding the signatures of functions that various tests require
- add accuracy and correctness tests for JAX

The JAX accuracy tests produce: https://github.com/pearu/functional_algorithms/issues/37 https://github.com/pearu/functional_algorithms/issues/38 https://github.com/pearu/functional_algorithms/issues/39 https://github.com/pearu/functional_algorithms/issues/40 https://github.com/pearu/functional_algorithms/issues/41 https://github.com/pearu/functional_algorithms/issues/42 https://github.com/pearu/functional_algorithms/issues/43 https://github.com/pearu/functional_algorithms/issues/44 https://github.com/pearu/functional_algorithms/issues/45 https://github.com/pearu/functional_algorithms/issues/46 https://github.com/pearu/functional_algorithms/issues/47 https://github.com/pearu/functional_algorithms/issues/48 https://github.com/pearu/functional_algorithms/issues/49 https://github.com/pearu/functional_algorithms/issues/50 https://github.com/pearu/functional_algorithms/issues/51 https://github.com/pearu/functional_algorithms/issues/52 https://github.com/pearu/functional_algorithms/issues/53 https://github.com/pearu/functional_algorithms/issues/54 https://github.com/pearu/functional_algorithms/issues/55