### PR TITLE
Evaluate x + x + x * x + y * y using Decker's product.

### DIFF
--- a/functional_algorithms/utils.py
+++ b/functional_algorithms/utils.py
@@ -263,6 +263,32 @@ def square_dekker(x):
     return r1, r2
 
 
+def add_twosum(x, y):
+    """Sum of x and y.
+
+    Return s, t such that
+
+      x + y = s + t
+    """
+    s = x + y
+    z = s - x
+    t = (x - (s - z)) + (y - z)
+    return s, t
+
+
+def double_twosum(x):
+    """
+
+    Return s, t such that
+
+      x + x = s + t
+    """
+    s = x + x
+    z = s - x
+    t = (x - (s - z)) + (x - z)
+    return s, t
+
+
 class vectorize_with_backend(numpy.vectorize):
 
     pyfunc_is_vectorized = False

--- a/tools/log1p_real_part.py
+++ b/tools/log1p_real_part.py
@@ -1,0 +1,67 @@
+"""See https://github.com/pearu/functional_algorithms/issues/70
+
+The resolution to the issue is based on using Dekker's product.
+
+References:
+  https://csclub.uwaterloo.ca/~pbarfuss/dekker1971.pdf
+  https://inria.hal.science/hal-04480440v1
+
+"""
+
+import mpmath
+import numpy as np
+from functional_algorithms import utils
+from collections import defaultdict
+
+
+def main():
+    dtype = np.float32
+    fi = np.finfo(dtype)
+
+    def expr1(x, y):
+        return x + x + x * x + y * y
+
+    def expr_decker(x, y):
+        x2_r1, x2_r2 = utils.double_twosum(x)  # same accuracy as using x + x
+        xx_r1, xx_r2 = utils.square_dekker(x)
+        yy_r1, yy_r2 = utils.square_dekker(y)
+        r = x2_r1
+        r += yy_r1
+        r += xx_r1
+        r += yy_r2
+        r += xx_r2
+        r += x2_r2
+        return r
+
+    def expr_mpmath(x, y):
+        ctx = mpmath.mp
+        ctx.prec = 5000
+        x_mp = utils.float2mpf(ctx, x)
+        y_mp = utils.float2mpf(ctx, y)
+
+        r = x_mp + x_mp + y_mp * y_mp + x_mp * x_mp
+        return utils.mpf2float(type(x), r)
+
+    min_y = np.sqrt(dtype(2) * np.sqrt(fi.smallest_subnormal))
+    min_y = 0
+
+    max_ulp_error_naive = 0
+    ulp_error_decker = defaultdict(int)
+
+    for y in utils.real_samples(size=10000, dtype=dtype, min_value=min_y, max_value=1):
+        x = -dtype(0.5) * y * y
+        r_naive = expr1(x, y)
+        r_decker = expr_decker(x, y)
+        r_mp = expr_mpmath(x, y)
+
+        d1 = utils.diff_ulp(r_naive, r_mp)
+        d2 = utils.diff_ulp(r_decker, r_mp)
+
+        max_ulp_error_naive = max(max_ulp_error_naive, d1)
+        ulp_error_decker[d2] += 1
+
+    print(f"{max_ulp_error_naive=} {dict(ulp_error_decker)=}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR introduces utility functions for evaluating polynomial
```
x + x + x * x + y * y
```
accurately in the region where `x` is close to `-y * y / 2` and `abs(y) < 1`.

This is a step forward for resolving accuracy issues in complex log1p, see https://github.com/pearu/functional_algorithms/issues/70.

The usage of Decker's product leads to the following accuracy statistics:
```
float16:
max_ulp_error_naive=239 dict(ulp_error_decker)={0: 6381, 1: 3391, 2: 228}
float32:
max_ulp_error_naive=674881016 dict(ulp_error_decker)={0: 9141, 1: 804, 2: 55}
float64:
ax_ulp_error_naive=4133603370539315421 dict(ulp_error_decker)={0: 9757, 1: 236, 2: 7}
```