### PR TITLE
Add complex sqrt

### DIFF
--- a/functional_algorithms/targets/cpp.py
+++ b/functional_algorithms/targets/cpp.py
@@ -28,6 +28,7 @@ trace_arguments = dict(
     # real_asin=[(":float", ":float")],
     # square=[(":float", ":float"), (":complex", ":complex")],
     # asin=[(":float", ":float"), (":complex", ":complex")],
+    complex_sqrt=[(":complex", ":complex")],
 )
 
 source_file_extension = ".cpp"

--- a/functional_algorithms/targets/numpy.py
+++ b/functional_algorithms/targets/numpy.py
@@ -78,6 +78,10 @@ trace_arguments = dict(
     log1p=[(":complex128",), (":complex64",), (":float64",), (":float32",)],
     hypot=[(":float32", ":float32"), (":float64", ":float64")],
     square=[(":complex128",), (":complex64",), (":float64",), (":float32",)],
+    sqrt=[
+        (":complex128",),
+        (":complex64",),
+    ],
 )
 
 

--- a/functional_algorithms/targets/python.py
+++ b/functional_algorithms/targets/python.py
@@ -32,6 +32,7 @@ trace_arguments = dict(
     hypot=[(":float", ":float")],
     square=[(":float",), (":complex",)],
     log1p=[(":float",), (":complex",)],
+    sqrt=[(":float",), (":complex",)][1:],
 )
 
 

--- a/functional_algorithms/targets/stablehlo.py
+++ b/functional_algorithms/targets/stablehlo.py
@@ -20,6 +20,7 @@ trace_arguments = dict(
     log1p=[(":float",), (":complex",)],
     hypot=[(":float", ":float")],
     square=[(":float",), (":complex",)],
+    sqrt=[(":complex",)],
 )
 
 

--- a/functional_algorithms/targets/xla_client.py
+++ b/functional_algorithms/targets/xla_client.py
@@ -29,6 +29,7 @@ trace_arguments = dict(
     atan=[(":float", ":float"), (":complex", ":complex")],
     atanh=[(":float", ":float"), (":complex", ":complex")],
     complex_log1p=[(":complex", ":complex")],
+    complex_sqrt=[(":complex", ":complex")],
 )
 
 source_file_extension = ".cc"

--- a/functional_algorithms/tests/test_accuracy.py
+++ b/functional_algorithms/tests/test_accuracy.py
@@ -1,10 +1,11 @@
 import numpy
 import functional_algorithms as fa
+import os
 import pytest
 import warnings
 
 
-@pytest.fixture(scope="function", params=["jax"])
+@pytest.fixture(scope="function", params=["jax", "functional_algorithms"])
 def backend(request):
     return request.param
 
@@ -25,9 +26,17 @@ def dtype(request):
 
 
 def test_unary(unary_func_name, backend, device, dtype):
-    pytest.importorskip(backend)
+    if backend == "functional_algorithms":
+        backend = "algorithms"
+    else:
+        pytest.importorskip(backend)
 
-    func = getattr(getattr(fa.utils, f"numpy_with_{backend}")(device=device), unary_func_name)
+    try:
+        func = getattr(getattr(fa.utils, f"numpy_with_{backend}")(device=device, dtype=dtype), unary_func_name)
+    except NotImplementedError as msg:
+        pytest.skip(f"{unary_func_name}: {msg}")
+    except AttributeError as msg:
+        pytest.skip(f"{unary_func_name}: {msg}")
 
     if not func.backend_is_available(device):
         pytest.skip(f"{device} support is unavailable")
@@ -43,7 +52,7 @@ def test_unary(unary_func_name, backend, device, dtype):
     # and smallest normal is defined as 1).
     fi = numpy.finfo(dtype)
     x = numpy.sqrt(fi.smallest_normal) * dtype(0.5)
-    v1 = getattr(getattr(fa.utils, f"numpy_with_{backend}")(device=device), "square")(x)
+    v1 = getattr(getattr(fa.utils, f"numpy_with_{backend}")(device=device, dtype=dtype), "square")(x)
     v2 = numpy.square(x)
     d = fa.utils.diff_ulp(v1, v2)
     if d > 1000:
@@ -56,11 +65,10 @@ def test_unary(unary_func_name, backend, device, dtype):
     reference = getattr(mpmath, unary_func_name)
     npy_reference = getattr(fa.utils.numpy_with_numpy(), unary_func_name)
 
-    re_blocks, im_blocks = 101, 52
-    re_blocksize, im_blocksize = 20, 20
-
-    if 0:
-        # used for testing
+    if int(os.environ.get("FA_HIGH_RESOLUTION", "0")):
+        re_blocks, im_blocks = 101, 52
+        re_blocksize, im_blocksize = 20, 20
+    else:
         re_blocks, im_blocks = 51, 26
         re_blocksize, im_blocksize = 5, 5
 
@@ -156,7 +164,7 @@ def test_unary(unary_func_name, backend, device, dtype):
     print(timage)
     print()
 
-    if fa_reference is not None:
+    if fa_reference is not None and backend != "algorithms":
         rows = [
             (
                 "ULP-difference",
@@ -188,7 +196,7 @@ def test_unary(unary_func_name, backend, device, dtype):
         clusters = fa.utils.Clusters()
         for re, im in zip(*numpy.where(ulp == value)):
             clusters.add((re, im))
-        for cluster in clusters:
+        for cluster in clusters.clusters + clusters.split().clusters:
             re, im = cluster.center_point()
             with warnings.catch_warnings(action="ignore"):
                 np_value = npy_reference(samples[re, im])
@@ -209,4 +217,4 @@ def test_unary(unary_func_name, backend, device, dtype):
     col_fmt = "| " + " | ".join([f"{{{i}:>{w}}}" for i, w in enumerate(col_widths)]) + " |"
     print("\n".join([col_fmt.format(*map(str, row)) for row in rows]))
 
-    pytest.xfail("inaccurate or incorrect results")
+    # pytest.xfail("inaccurate or incorrect results")

--- a/functional_algorithms/tests/test_accuracy.py
+++ b/functional_algorithms/tests/test_accuracy.py
@@ -217,4 +217,4 @@ def test_unary(unary_func_name, backend, device, dtype):
     col_fmt = "| " + " | ".join([f"{{{i}:>{w}}}" for i, w in enumerate(col_widths)]) + " |"
     print("\n".join([col_fmt.format(*map(str, row)) for row in rows]))
 
-    # pytest.xfail("inaccurate or incorrect results")
+    pytest.xfail("inaccurate or incorrect results")

--- a/results/README.md
+++ b/results/README.md
@@ -84,6 +84,8 @@ Finally,
 | square | complex128 | 995705 | 6296 | - | - | - | - |
 | sqrt | float32 | 1000001 | - | - | - | - | using native sqrt |
 | sqrt | complex64 | 639573 | 362328 | 100 | - | - | using native sqrt |
+| sqrt<sub>2</sub> | complex64 | 639573 | 362328 | 100 | - | - | using native sqrt |
+| sqrt | complex128 | 637905 | 364008 | 88 | - | - | - |
 | angle | complex64 | 940289 | 61332 | 376 | 4 | - | - |
 | angle | complex128 | 989787 | 12214 | - | - | - | - |
 | log1p | complex64 | 905931 | 94401 | 1661 | 8 | - | - |

--- a/results/cpp/complex_sqrt.cpp
+++ b/results/cpp/complex_sqrt.cpp
@@ -1,0 +1,84 @@
+// This file is generated using functional_algorithms tool (0.11.1), see
+//   https://github.com/pearu/functional_algorithms
+// for more information.
+
+
+
+#include <algorithm>
+#include <cmath>
+#include <complex>
+#include <cstdint>
+#include <limits>
+
+
+std::complex<double> complex_sqrt_0(std::complex<double> z) {
+  double x = (z).real();
+  double constant_f0 = 0.0;
+  double ax = std::abs(x);
+  double y = (z).imag();
+  double ay = std::abs(y);
+  bool eq_ax_ay = (ax) == (ay);
+  double sq_ax = std::sqrt(ax);
+  double sq_2 = 1.4142135623730951;
+  double mx = std::max(ax, ay);
+  double mn = std::min(ax, ay);
+  double one = 1.0;
+  double mn_over_mx = (mn) / (mx);
+  double r = (mn_over_mx) * (mn_over_mx);
+  double sqa = std::sqrt((one) + (r));
+  double two = 2.0;
+  double u_general = std::sqrt(
+      (((((mx) == (mn)) ? ((sq_2) * (mx))
+                        : (((((sqa) == (one)) && ((r) > (constant_f0)))
+                                ? ((mx) + (((mx) * (r)) / (two)))
+                                : ((mx) * (sqa)))))) /
+       (two)) +
+      ((ax) / (two)));
+  bool logical_or_eq_u_general_constant_f0_eq_u_general_constant_posinf =
+      ((u_general) == (constant_f0)) ||
+      ((u_general) == (std::numeric_limits<double>::infinity()));
+  bool gt_ax_ay = (ax) > (ay);
+  bool lt_ax_ay = (ax) < (ay);
+  double _r_0_ =
+      ((eq_ax_ay) ? (one) : (((lt_ax_ay) ? ((ax) / (ay)) : ((ay) / (ax)))));
+  double abs__r_0_ = std::abs(_r_0_);
+  double _mx_0_ = std::max(one, abs__r_0_);
+  double _mn_0_ = std::min(one, abs__r_0_);
+  double _mn_over_mx_0_ = (_mn_0_) / (_mx_0_);
+  double _r_1_ = (_mn_over_mx_0_) * (_mn_over_mx_0_);
+  double _sqa_0_ = std::sqrt((one) + (_r_1_));
+  double h = (((_mx_0_) == (_mn_0_))
+                  ? ((sq_2) * (_mx_0_))
+                  : (((((_sqa_0_) == (one)) && ((_r_1_) > (constant_f0)))
+                          ? ((_mx_0_) + (((_mx_0_) * (_r_1_)) / (two)))
+                          : ((_mx_0_) * (_sqa_0_)))));
+  double sq_1h = std::sqrt((one) + (h));
+  double sq_ay = std::sqrt(ay);
+  double sq_rh = std::sqrt((_r_0_) + (h));
+  double u =
+      ((eq_ax_ay)
+           ? (((sq_ax) * (1.5537739740300374)) / (sq_2))
+           : (((logical_or_eq_u_general_constant_f0_eq_u_general_constant_posinf)
+                   ? (((gt_ax_ay) ? ((sq_ax) * ((sq_1h) / (sq_2)))
+                                  : ((sq_ay) * ((sq_rh) / (sq_2)))))
+                   : (u_general))));
+  double ay_div_u =
+      ((eq_ax_ay)
+           ? ((sq_ay) / (2.19736822693562))
+           : (((logical_or_eq_u_general_constant_f0_eq_u_general_constant_posinf)
+                   ? (((gt_ax_ay)
+                           ? (((sq_ay) *
+                               (((eq_ax_ay)
+                                     ? (one)
+                                     : (((lt_ax_ay) ? ((sq_ax) / (sq_ay))
+                                                    : ((sq_ay) / (sq_ax))))))) /
+                              ((sq_1h) * (sq_2)))
+                           : ((sq_ay) / ((sq_rh) * (sq_2)))))
+                   : ((ay) / ((u_general) * (two))))));
+  bool lt_y_constant_f0 = (y) < (constant_f0);
+  return std::complex<double>(
+      (((x) >= (constant_f0)) ? (u) : (ay_div_u)),
+      (((x) < (constant_f0))
+           ? (((lt_y_constant_f0) ? (-(u)) : (u)))
+           : (((lt_y_constant_f0) ? (-(ay_div_u)) : (ay_div_u)))));
+}

--- a/results/estimate_accuracy.py
+++ b/results/estimate_accuracy.py
@@ -83,9 +83,9 @@ def get_inputs():
         # ("sqrt", np.float32, {}),     # real_sqrt is not implemented
         ("sqrt", np.float32, dict(use_native_sqrt=True)),
         # ("sqrt", np.float64, {}),     # real_sqrt is not implemented
-        # ("sqrt", np.complex64, {}),   # complex_sqrt is not implemented
+        ("sqrt", np.complex64, {}),
         ("sqrt", np.complex64, dict(use_native_sqrt=True)),
-        # ("sqrt", np.complex128, {}),  # complex_sqrt is not implemented
+        ("sqrt", np.complex128, {}),
         ("angle", np.complex64, {}),
         ("angle", np.complex128, {}),
         # ("log1p", np.float32, {}),  # real_log1p is not implemented

--- a/results/numpy/sqrt.py
+++ b/results/numpy/sqrt.py
@@ -1,0 +1,137 @@
+# This file is generated using functional_algorithms tool (0.11.1), see
+#   https://github.com/pearu/functional_algorithms
+# for more information.
+
+
+import numpy
+import warnings
+
+
+def make_complex(r, i):
+    if r.dtype == numpy.float32 and i.dtype == numpy.float32:
+        return numpy.array([r, i]).view(numpy.complex64)[0]
+    elif i.dtype == numpy.float64 and i.dtype == numpy.float64:
+        return numpy.array([r, i]).view(numpy.complex128)[0]
+    raise NotImplementedError((r.dtype, i.dtype))
+
+
+def sqrt_0(z: numpy.complex128) -> numpy.complex128:
+    with warnings.catch_warnings(action="ignore"):
+        z = numpy.complex128(z)
+        x: numpy.float64 = (z).real
+        constant_f0: numpy.float64 = numpy.float64(0.0)
+        ax: numpy.float64 = numpy.abs(x)
+        y: numpy.float64 = (z).imag
+        ay: numpy.float64 = numpy.abs(y)
+        eq_ax_ay: numpy.bool_ = numpy.equal(ax, ay, dtype=numpy.bool_)
+        sq_ax: numpy.float64 = numpy.sqrt(ax)
+        sq_2: numpy.float64 = numpy.float64(1.4142135623730951)
+        two: numpy.float64 = numpy.float64(2.0)
+        u_general: numpy.float64 = numpy.sqrt(((numpy.hypot(ax, ay)) / (two)) + ((ax) / (two)))
+        logical_or_eq_u_general_constant_f0_eq_u_general_constant_posinf: numpy.bool_ = (
+            numpy.equal(u_general, constant_f0, dtype=numpy.bool_)
+        ) or (numpy.equal(u_general, numpy.float64(numpy.inf), dtype=numpy.bool_))
+        gt_ax_ay: numpy.bool_ = (ax) > (ay)
+        one: numpy.float64 = numpy.float64(1.0)
+        lt_ax_ay: numpy.bool_ = (ax) < (ay)
+        r: numpy.float64 = (one) if (eq_ax_ay) else (((ax) / (ay)) if (lt_ax_ay) else ((ay) / (ax)))
+        h: numpy.float64 = numpy.hypot(one, r)
+        sq_1h: numpy.float64 = numpy.sqrt((one) + (h))
+        sq_ay: numpy.float64 = numpy.sqrt(ay)
+        sq_rh: numpy.float64 = numpy.sqrt((r) + (h))
+        u: numpy.float64 = (
+            (((sq_ax) * (numpy.float64(1.5537739740300374))) / (sq_2))
+            if (eq_ax_ay)
+            else (
+                (((sq_ax) * ((sq_1h) / (sq_2))) if (gt_ax_ay) else ((sq_ay) * ((sq_rh) / (sq_2))))
+                if (logical_or_eq_u_general_constant_f0_eq_u_general_constant_posinf)
+                else (u_general)
+            )
+        )
+        ay_div_u: numpy.float64 = (
+            ((sq_ay) / (numpy.float64(2.19736822693562)))
+            if (eq_ax_ay)
+            else (
+                (
+                    (
+                        ((sq_ay) * ((one) if (eq_ax_ay) else (((sq_ax) / (sq_ay)) if (lt_ax_ay) else ((sq_ay) / (sq_ax)))))
+                        / ((sq_1h) * (sq_2))
+                    )
+                    if (gt_ax_ay)
+                    else ((sq_ay) / ((sq_rh) * (sq_2)))
+                )
+                if (logical_or_eq_u_general_constant_f0_eq_u_general_constant_posinf)
+                else ((ay) / ((u_general) * (two)))
+            )
+        )
+        lt_y_constant_f0: numpy.bool_ = (y) < (constant_f0)
+        result = make_complex(
+            (u) if ((x) >= (constant_f0)) else (ay_div_u),
+            (
+                ((-(u)) if (lt_y_constant_f0) else (u))
+                if ((x) < (constant_f0))
+                else ((-(ay_div_u)) if (lt_y_constant_f0) else (ay_div_u))
+            ),
+        )
+        return result
+
+
+def sqrt_1(z: numpy.complex64) -> numpy.complex64:
+    with warnings.catch_warnings(action="ignore"):
+        z = numpy.complex64(z)
+        x: numpy.float32 = (z).real
+        constant_f0: numpy.float32 = numpy.float32(0.0)
+        ax: numpy.float32 = numpy.abs(x)
+        y: numpy.float32 = (z).imag
+        ay: numpy.float32 = numpy.abs(y)
+        eq_ax_ay: numpy.bool_ = numpy.equal(ax, ay, dtype=numpy.bool_)
+        sq_ax: numpy.float32 = numpy.sqrt(ax)
+        sq_2: numpy.float32 = numpy.float32(1.4142135)
+        two: numpy.float32 = numpy.float32(2.0)
+        u_general: numpy.float32 = numpy.sqrt(((numpy.hypot(ax, ay)) / (two)) + ((ax) / (two)))
+        logical_or_eq_u_general_constant_f0_eq_u_general_constant_posinf: numpy.bool_ = (
+            numpy.equal(u_general, constant_f0, dtype=numpy.bool_)
+        ) or (numpy.equal(u_general, numpy.float32(numpy.inf), dtype=numpy.bool_))
+        gt_ax_ay: numpy.bool_ = (ax) > (ay)
+        one: numpy.float32 = numpy.float32(1.0)
+        lt_ax_ay: numpy.bool_ = (ax) < (ay)
+        r: numpy.float32 = (one) if (eq_ax_ay) else (((ax) / (ay)) if (lt_ax_ay) else ((ay) / (ax)))
+        h: numpy.float32 = numpy.hypot(one, r)
+        sq_1h: numpy.float32 = numpy.sqrt((one) + (h))
+        sq_ay: numpy.float32 = numpy.sqrt(ay)
+        sq_rh: numpy.float32 = numpy.sqrt((r) + (h))
+        u: numpy.float32 = (
+            (((sq_ax) * (numpy.float32(1.553774))) / (sq_2))
+            if (eq_ax_ay)
+            else (
+                (((sq_ax) * ((sq_1h) / (sq_2))) if (gt_ax_ay) else ((sq_ay) * ((sq_rh) / (sq_2))))
+                if (logical_or_eq_u_general_constant_f0_eq_u_general_constant_posinf)
+                else (u_general)
+            )
+        )
+        ay_div_u: numpy.float32 = (
+            ((sq_ay) / (numpy.float32(2.1973681)))
+            if (eq_ax_ay)
+            else (
+                (
+                    (
+                        ((sq_ay) * ((one) if (eq_ax_ay) else (((sq_ax) / (sq_ay)) if (lt_ax_ay) else ((sq_ay) / (sq_ax)))))
+                        / ((sq_1h) * (sq_2))
+                    )
+                    if (gt_ax_ay)
+                    else ((sq_ay) / ((sq_rh) * (sq_2)))
+                )
+                if (logical_or_eq_u_general_constant_f0_eq_u_general_constant_posinf)
+                else ((ay) / ((u_general) * (two)))
+            )
+        )
+        lt_y_constant_f0: numpy.bool_ = (y) < (constant_f0)
+        result = make_complex(
+            (u) if ((x) >= (constant_f0)) else (ay_div_u),
+            (
+                ((-(u)) if (lt_y_constant_f0) else (u))
+                if ((x) < (constant_f0))
+                else ((-(ay_div_u)) if (lt_y_constant_f0) else (ay_div_u))
+            ),
+        )
+        return result

--- a/results/python/sqrt.py
+++ b/results/python/sqrt.py
@@ -1,0 +1,94 @@
+# This file is generated using functional_algorithms tool (0.11.1), see
+#   https://github.com/pearu/functional_algorithms
+# for more information.
+
+
+import math
+import sys
+
+
+def sqrt_0(z: complex) -> complex:
+    x: float = (z).real
+    constant_f0: float = 0.0
+    ax: float = abs(x)
+    y: float = (z).imag
+    ay: float = abs(y)
+    eq_ax_ay: bool = (ax) == (ay)
+    sq_ax: float = math.sqrt(ax)
+    sq_2: float = 1.4142135623730951
+    mx: float = max(ax, ay)
+    mn: float = min(ax, ay)
+    one: float = 1.0
+    mn_over_mx: float = (mn) / (mx)
+    r: float = (mn_over_mx) * (mn_over_mx)
+    sqa: float = math.sqrt((one) + (r))
+    two: float = 2.0
+    u_general: float = math.sqrt(
+        (
+            (
+                ((sq_2) * (mx))
+                if ((mx) == (mn))
+                else (((mx) + (((mx) * (r)) / (two))) if (((sqa) == (one)) and ((r) > (constant_f0))) else ((mx) * (sqa)))
+            )
+            / (two)
+        )
+        + ((ax) / (two))
+    )
+    logical_or_eq_u_general_constant_f0_eq_u_general_constant_posinf: bool = ((u_general) == (constant_f0)) or (
+        (u_general) == (math.inf)
+    )
+    gt_ax_ay: bool = (ax) > (ay)
+    lt_ax_ay: bool = (ax) < (ay)
+    _r_0_: float = (one) if (eq_ax_ay) else (((ax) / (ay)) if (lt_ax_ay) else ((ay) / (ax)))
+    abs__r_0_: float = abs(_r_0_)
+    _mx_0_: float = max(one, abs__r_0_)
+    _mn_0_: float = min(one, abs__r_0_)
+    _mn_over_mx_0_: float = (_mn_0_) / (_mx_0_)
+    _r_1_: float = (_mn_over_mx_0_) * (_mn_over_mx_0_)
+    _sqa_0_: float = math.sqrt((one) + (_r_1_))
+    h: float = (
+        ((sq_2) * (_mx_0_))
+        if ((_mx_0_) == (_mn_0_))
+        else (
+            ((_mx_0_) + (((_mx_0_) * (_r_1_)) / (two)))
+            if (((_sqa_0_) == (one)) and ((_r_1_) > (constant_f0)))
+            else ((_mx_0_) * (_sqa_0_))
+        )
+    )
+    sq_1h: float = math.sqrt((one) + (h))
+    sq_ay: float = math.sqrt(ay)
+    sq_rh: float = math.sqrt((_r_0_) + (h))
+    u: float = (
+        (((sq_ax) * (1.5537739740300374)) / (sq_2))
+        if (eq_ax_ay)
+        else (
+            (((sq_ax) * ((sq_1h) / (sq_2))) if (gt_ax_ay) else ((sq_ay) * ((sq_rh) / (sq_2))))
+            if (logical_or_eq_u_general_constant_f0_eq_u_general_constant_posinf)
+            else (u_general)
+        )
+    )
+    ay_div_u: float = (
+        ((sq_ay) / (2.19736822693562))
+        if (eq_ax_ay)
+        else (
+            (
+                (
+                    ((sq_ay) * ((one) if (eq_ax_ay) else (((sq_ax) / (sq_ay)) if (lt_ax_ay) else ((sq_ay) / (sq_ax)))))
+                    / ((sq_1h) * (sq_2))
+                )
+                if (gt_ax_ay)
+                else ((sq_ay) / ((sq_rh) * (sq_2)))
+            )
+            if (logical_or_eq_u_general_constant_f0_eq_u_general_constant_posinf)
+            else ((ay) / ((u_general) * (two)))
+        )
+    )
+    lt_y_constant_f0: bool = (y) < (constant_f0)
+    return complex(
+        (u) if ((x) >= (constant_f0)) else (ay_div_u),
+        (
+            ((-(u)) if (lt_y_constant_f0) else (u))
+            if ((x) < (constant_f0))
+            else ((-(ay_div_u)) if (lt_y_constant_f0) else (ay_div_u))
+        ),
+    )

--- a/results/stablehlo/sqrt.td
+++ b/results/stablehlo/sqrt.td
@@ -1,0 +1,180 @@
+// This file is generated using functional_algorithms tool (0.11.1), see
+//   https://github.com/pearu/functional_algorithms
+// for more information.
+
+
+
+
+def : Pat<(sqrt_0 ComplexElementType:$z),
+  (StableHLO_ComplexOp
+    (StableHLO_SelectOp
+      (StableHLO_CompareOp
+       (StableHLO_RealOp:$x $z),
+       (StableHLO_ConstantLike<"0.0">:$constant_f0 $x),
+        StableHLO_ComparisonDirectionValue<"GE">,
+        (STABLEHLO_DEFAULT_COMPARISON_TYPE)),
+      (StableHLO_SelectOp:$u
+        (StableHLO_CompareOp:$eq_ax_ay
+         (StableHLO_AbsOp:$ax $x),
+         (StableHLO_AbsOp:$ay
+           (StableHLO_ImagOp:$y $z)),
+          StableHLO_ComparisonDirectionValue<"EQ">,
+          (STABLEHLO_DEFAULT_COMPARISON_TYPE)),
+        (StableHLO_DivOp
+          (StableHLO_MulOp
+            (StableHLO_SqrtOp:$sq_ax $ax),
+            (StableHLO_ConstantLike<"1.5537739740300374"> $x)),
+          (StableHLO_ConstantLike<"1.4142135623730951">:$sq_2 $x)),
+        (StableHLO_SelectOp
+          (StableHLO_OrOp:$logical_or_eq_u_general_constant_f0_eq_u_general_constant_posinf
+            (StableHLO_CompareOp
+             (StableHLO_SqrtOp:$u_general
+               (StableHLO_AddOp
+                 (StableHLO_DivOp
+                   (StableHLO_SelectOp
+                     (StableHLO_CompareOp
+                      (StableHLO_MaxOp:$mx $ax, $ay),
+                      (StableHLO_MinOp:$mn $ax, $ay),
+                       StableHLO_ComparisonDirectionValue<"EQ">,
+                       (STABLEHLO_DEFAULT_COMPARISON_TYPE)),
+                     (StableHLO_MulOp $sq_2, $mx),
+                     (StableHLO_SelectOp
+                       (StableHLO_AndOp
+                         (StableHLO_CompareOp
+                          (StableHLO_SqrtOp:$sqa
+                            (StableHLO_AddOp
+                              (StableHLO_ConstantLike<"1.0">:$one $x),
+                              (StableHLO_MulOp:$r
+                                (StableHLO_DivOp:$mn_over_mx $mn, $mx),
+                                $mn_over_mx))),
+                          $one,
+                           StableHLO_ComparisonDirectionValue<"EQ">,
+                           (STABLEHLO_DEFAULT_COMPARISON_TYPE)),
+                         (StableHLO_CompareOp
+                          $r,
+                          $constant_f0,
+                           StableHLO_ComparisonDirectionValue<"GT">,
+                           (STABLEHLO_DEFAULT_COMPARISON_TYPE))),
+                       (StableHLO_AddOp
+                         $mx,
+                         (StableHLO_DivOp
+                           (StableHLO_MulOp $mx, $r),
+                           (StableHLO_ConstantLike<"2.0">:$two $x))),
+                       (StableHLO_MulOp $mx, $sqa))),
+                   $two),
+                 (StableHLO_DivOp $ax, $two))),
+             $constant_f0,
+              StableHLO_ComparisonDirectionValue<"EQ">,
+              (STABLEHLO_DEFAULT_COMPARISON_TYPE)),
+            (StableHLO_CompareOp
+             $u_general,
+             (StableHLO_ConstantLikePosInfValue $x),
+              StableHLO_ComparisonDirectionValue<"EQ">,
+              (STABLEHLO_DEFAULT_COMPARISON_TYPE))),
+          (StableHLO_SelectOp
+            (StableHLO_CompareOp:$gt_ax_ay
+             $ax,
+             $ay,
+              StableHLO_ComparisonDirectionValue<"GT">,
+              (STABLEHLO_DEFAULT_COMPARISON_TYPE)),
+            (StableHLO_MulOp
+              $sq_ax,
+              (StableHLO_DivOp
+                (StableHLO_SqrtOp:$sq_1h
+                  (StableHLO_AddOp
+                    $one,
+                    (StableHLO_SelectOp:$h
+                      (StableHLO_CompareOp
+                       (StableHLO_MaxOp:$_mx_0_
+                         $one,
+                         (StableHLO_AbsOp:$abs__r_0_
+                           (StableHLO_SelectOp:$_r_0_
+                             $eq_ax_ay,
+                             $one,
+                             (StableHLO_SelectOp
+                               (StableHLO_CompareOp:$lt_ax_ay
+                                $ax,
+                                $ay,
+                                 StableHLO_ComparisonDirectionValue<"LT">,
+                                 (STABLEHLO_DEFAULT_COMPARISON_TYPE)),
+                               (StableHLO_DivOp $ax, $ay),
+                               (StableHLO_DivOp $ay, $ax))))),
+                       (StableHLO_MinOp:$_mn_0_ $one, $abs__r_0_),
+                        StableHLO_ComparisonDirectionValue<"EQ">,
+                        (STABLEHLO_DEFAULT_COMPARISON_TYPE)),
+                      (StableHLO_MulOp $sq_2, $_mx_0_),
+                      (StableHLO_SelectOp
+                        (StableHLO_AndOp
+                          (StableHLO_CompareOp
+                           (StableHLO_SqrtOp:$_sqa_0_
+                             (StableHLO_AddOp
+                               $one,
+                               (StableHLO_MulOp:$_r_1_
+                                 (StableHLO_DivOp:$_mn_over_mx_0_ $_mn_0_, $_mx_0_),
+                                 $_mn_over_mx_0_))),
+                           $one,
+                            StableHLO_ComparisonDirectionValue<"EQ">,
+                            (STABLEHLO_DEFAULT_COMPARISON_TYPE)),
+                          (StableHLO_CompareOp
+                           $_r_1_,
+                           $constant_f0,
+                            StableHLO_ComparisonDirectionValue<"GT">,
+                            (STABLEHLO_DEFAULT_COMPARISON_TYPE))),
+                        (StableHLO_AddOp
+                          $_mx_0_,
+                          (StableHLO_DivOp
+                            (StableHLO_MulOp $_mx_0_, $_r_1_),
+                            $two)),
+                        (StableHLO_MulOp $_mx_0_, $_sqa_0_))))),
+                $sq_2)),
+            (StableHLO_MulOp
+              (StableHLO_SqrtOp:$sq_ay $ay),
+              (StableHLO_DivOp
+                (StableHLO_SqrtOp:$sq_rh
+                  (StableHLO_AddOp $_r_0_, $h)),
+                $sq_2))),
+          $u_general)),
+      (StableHLO_SelectOp:$ay_div_u
+        $eq_ax_ay,
+        (StableHLO_DivOp
+          $sq_ay,
+          (StableHLO_ConstantLike<"2.19736822693562"> $x)),
+        (StableHLO_SelectOp
+          $logical_or_eq_u_general_constant_f0_eq_u_general_constant_posinf,
+          (StableHLO_SelectOp
+            $gt_ax_ay,
+            (StableHLO_DivOp
+              (StableHLO_MulOp
+                $sq_ay,
+                (StableHLO_SelectOp
+                  $eq_ax_ay,
+                  $one,
+                  (StableHLO_SelectOp
+                    $lt_ax_ay,
+                    (StableHLO_DivOp $sq_ax, $sq_ay),
+                    (StableHLO_DivOp $sq_ay, $sq_ax)))),
+              (StableHLO_MulOp $sq_1h, $sq_2)),
+            (StableHLO_DivOp
+              $sq_ay,
+              (StableHLO_MulOp $sq_rh, $sq_2))),
+          (StableHLO_DivOp
+            $ay,
+            (StableHLO_MulOp $u_general, $two))))),
+    (StableHLO_SelectOp
+      (StableHLO_CompareOp
+       $x,
+       $constant_f0,
+        StableHLO_ComparisonDirectionValue<"LT">,
+        (STABLEHLO_DEFAULT_COMPARISON_TYPE)),
+      (StableHLO_SelectOp
+        (StableHLO_CompareOp:$lt_y_constant_f0
+         $y,
+         $constant_f0,
+          StableHLO_ComparisonDirectionValue<"LT">,
+          (STABLEHLO_DEFAULT_COMPARISON_TYPE)),
+        (StableHLO_NegOp $u),
+        $u),
+      (StableHLO_SelectOp
+        $lt_y_constant_f0,
+        (StableHLO_NegOp $ay_div_u),
+        $ay_div_u)))>;

--- a/results/xla_client/complex_sqrt.cc
+++ b/results/xla_client/complex_sqrt.cc
@@ -1,0 +1,81 @@
+// This file is generated using functional_algorithms tool (0.11.1), see
+//   https://github.com/pearu/functional_algorithms
+// for more information.
+
+
+
+#include "xla/client/lib/constants.h"
+#include "xla/client/xla_builder.h"
+#include <limits>
+
+
+template <typename FloatType>
+XlaOp complex_sqrt_0(XlaOp z) {
+  XlaOp x = Real(z);
+  XlaOp constant_constant_0 = ScalarLike(x, 0);
+  XlaOp ax = Abs(x);
+  XlaOp y = Imag(z);
+  XlaOp ay = Abs(y);
+  XlaOp eq_ax_ay = Eq(ax, ay);
+  XlaOp sq_ax = Sqrt(ax);
+  FloatType sq_2_ = std::sqrt(2);
+  FloatType sq_12_ = std::sqrt((1) + (sq_2_));
+  XlaOp sq_2 = ScalarLike(x, sq_2_);
+  XlaOp mx = Max(ax, ay);
+  XlaOp mn = Min(ax, ay);
+  XlaOp one = ScalarLike(x, 1);
+  XlaOp r = Square(Div(mn, mx));
+  XlaOp sqa = Sqrt(Add(one, r));
+  XlaOp two = ScalarLike(x, 2);
+  XlaOp u_general =
+      Sqrt(Add(Div(Select(Eq(mx, mn), Mul(sq_2, mx),
+                          Select(And(Eq(sqa, one), Gt(r, constant_constant_0)),
+                                 Add(mx, Div(Mul(mx, r), two)), Mul(mx, sqa))),
+                   two),
+               Div(ax, two)));
+  XlaOp
+      logical_or_eq_u_general_constant_constant_0_eq_u_general_constant_constant_posinf =
+          Or(Eq(u_general, constant_constant_0),
+             Eq(u_general,
+                ScalarLike(x, std::numeric_limits<FloatType>::infinity())));
+  XlaOp gt_ax_ay = Gt(ax, ay);
+  XlaOp lt_ax_ay = Lt(ax, ay);
+  XlaOp _r_0_ =
+      Select(eq_ax_ay, one, Select(lt_ax_ay, Div(ax, ay), Div(ay, ax)));
+  XlaOp abs__r_0_ = Abs(_r_0_);
+  XlaOp _mx_0_ = Max(one, abs__r_0_);
+  XlaOp _mn_0_ = Min(one, abs__r_0_);
+  XlaOp _r_1_ = Square(Div(_mn_0_, _mx_0_));
+  XlaOp _sqa_0_ = Sqrt(Add(one, _r_1_));
+  XlaOp h = Select(
+      Eq(_mx_0_, _mn_0_), Mul(sq_2, _mx_0_),
+      Select(And(Eq(_sqa_0_, one), Gt(_r_1_, constant_constant_0)),
+             Add(_mx_0_, Div(Mul(_mx_0_, _r_1_), two)), Mul(_mx_0_, _sqa_0_)));
+  XlaOp sq_1h = Sqrt(Add(one, h));
+  XlaOp sq_ay = Sqrt(ay);
+  XlaOp sq_rh = Sqrt(Add(_r_0_, h));
+  XlaOp u = Select(
+      eq_ax_ay, Div(Mul(sq_ax, ScalarLike(x, sq_12_)), sq_2),
+      Select(
+          logical_or_eq_u_general_constant_constant_0_eq_u_general_constant_constant_posinf,
+          Select(gt_ax_ay, Mul(sq_ax, Div(sq_1h, sq_2)),
+                 Mul(sq_ay, Div(sq_rh, sq_2))),
+          u_general));
+  XlaOp ay_div_u = Select(
+      eq_ax_ay, Div(sq_ay, ScalarLike(x, (sq_12_) * (sq_2_))),
+      Select(
+          logical_or_eq_u_general_constant_constant_0_eq_u_general_constant_constant_posinf,
+          Select(gt_ax_ay,
+                 Div(Mul(sq_ay, Select(eq_ax_ay, one,
+                                       Select(lt_ax_ay, Div(sq_ax, sq_ay),
+                                              Div(sq_ay, sq_ax)))),
+                     Mul(sq_1h, sq_2)),
+                 Div(sq_ay, Mul(sq_rh, sq_2))),
+          Div(ay, Mul(u_general, two))));
+  XlaOp lt_y_constant_constant_0 = Lt(y, constant_constant_0);
+  return Complex(
+      Select(Ge(x, constant_constant_0), u, ay_div_u),
+      Select(Lt(x, constant_constant_0),
+             Select(lt_y_constant_constant_0, Neg(u), u),
+             Select(lt_y_constant_constant_0, Neg(ay_div_u), ay_div_u)));
+}


### PR DESCRIPTION
As in the title.

In addition:
- introduce `FA_HIGH_RESOLUTION` environment variable. When set to `1`, test_accuracy will use high-resolution samples (about 2,000,000 samples),
- add `conj` to algorithms,
- add `vectorize_with_numpy` that is used by functions that `targets.numpy.as_function` generates.