### PR TITLE
Add expander_name to stablehlo printer

### DIFF
--- a/functional_algorithms/targets/stablehlo.py
+++ b/functional_algorithms/targets/stablehlo.py
@@ -143,8 +143,9 @@ class Printer:
             sargs = ", ".join(sargs)
 
             lines = []
+            expander_name = expr.props.get("expander_name", "")
             chlo_name = expr.props.get("name", f"CHLO_{name.ref.title()}")
-            lines.append(f"{tab}def : Pat<({chlo_name} {sargs}),")
+            lines.append(f"{tab}def {expander_name}: Pat<({chlo_name} {sargs}),")
 
             for line in self.tostring(body, tab=tab + "  ").splitlines():
                 sline = line.lstrip()

--- a/results/README.md
+++ b/results/README.md
@@ -84,7 +84,7 @@ Finally,
 | square | complex128 | 995705 | 6296 | - | - | - | - |
 | sqrt | float32 | 1000001 | - | - | - | - | using native sqrt |
 | sqrt | complex64 | 639573 | 362328 | 100 | - | - | using native sqrt |
-| sqrt<sub>2</sub> | complex64 | 639573 | 362328 | 100 | - | - | using native sqrt |
+| sqrt<sub>2</sub> | complex64 | 644997 | 356784 | 212 | 8 | - | - |
 | sqrt | complex128 | 637905 | 364008 | 88 | - | - | - |
 | angle | complex64 | 940289 | 61332 | 376 | 4 | - | - |
 | angle | complex128 | 989787 | 12214 | - | - | - | - |

--- a/results/estimate_accuracy.py
+++ b/results/estimate_accuracy.py
@@ -83,8 +83,8 @@ def get_inputs():
         # ("sqrt", np.float32, {}),     # real_sqrt is not implemented
         ("sqrt", np.float32, dict(use_native_sqrt=True)),
         # ("sqrt", np.float64, {}),     # real_sqrt is not implemented
-        ("sqrt", np.complex64, {}),
         ("sqrt", np.complex64, dict(use_native_sqrt=True)),
+        ("sqrt", np.complex64, {}),
         ("sqrt", np.complex128, {}),
         ("angle", np.complex64, {}),
         ("angle", np.complex128, {}),


### PR DESCRIPTION
As in the title.

Addresses the TODO item in https://github.com/openxla/stablehlo/blob/960b2318ab3c96b13a5b053485b71e155ef41351/build_tools/math/generate_ChloDecompositionPatternsMath.py#L121