### PR TITLE
Add real samples support to accuracy tests.

### DIFF
--- a/functional_algorithms/algorithms.py
+++ b/functional_algorithms/algorithms.py
@@ -789,21 +789,6 @@ def acosh(ctx, z: complex | float):
     assert 0  # unreachable
 
 
-@definition("sqrt", domain="real")
-def real_sqrt(ctx, z: float):
-    return NotImplemented
-
-
-@definition("sqrt", domain="complex")
-def complex_sqrt(ctx, z: complex):
-    return NotImplemented
-
-
-@definition("sqrt")
-def sqrt(ctx, z: complex | float):
-    assert 0  # unreachable
-
-
 @definition("angle", domain="complex")
 def angle(ctx, z: complex):
     return ctx.atan2(z.imag, z.real)

--- a/functional_algorithms/tests/test_accuracy.py
+++ b/functional_algorithms/tests/test_accuracy.py
@@ -94,22 +94,46 @@ def test_unary(unary_func_name, backend, device, dtype, fpu):
     reference = getattr(mpmath, unary_func_name)
     npy_reference = getattr(fa.utils.numpy_with_numpy(), unary_func_name)
 
-    if int(os.environ.get("FA_HIGH_RESOLUTION", "0")):
-        re_blocks, im_blocks = 101, 52
-        re_blocksize, im_blocksize = 20, 20
-    else:
-        re_blocks, im_blocks = 51, 26
-        re_blocksize, im_blocksize = 5, 5
-
-    re_size, im_size = re_blocks * re_blocksize, im_blocks * im_blocksize
+    complex_plane = False
+    real_line = False
 
     if dtype in {numpy.complex64, numpy.complex128}:
+        complex_plane = True
+        if int(os.environ.get("FA_HIGH_RESOLUTION", "0")):
+            re_blocks, im_blocks = 101, 52
+            re_blocksize, im_blocksize = 20, 20
+        else:
+            re_blocks, im_blocks = 51, 26
+            re_blocksize, im_blocksize = 5, 5
+
+        re_size, im_size = re_blocks * re_blocksize, im_blocks * im_blocksize
+
         samples = fa.utils.complex_samples(
             (re_size, im_size), dtype=dtype, include_subnormal=include_subnormal, **samples_limits
         )
+
+        assert samples.shape == (im_size, re_size)
+    elif dtype in {numpy.float32, numpy.float64}:
+        real_line = True
+        if int(os.environ.get("FA_HIGH_RESOLUTION", "0")):
+            rows = 52
+            blocks = 101
+            blocksize = 400
+        else:
+            rows = 26
+            blocks = 51
+            blocksize = 5
+
+        samples = fa.utils.real_samples(
+            rows * blocks * blocksize,
+            dtype=dtype,
+            include_subnormal=include_subnormal,
+            include_zero=False,
+        )
+        assert samples.size == rows * blocks * blocksize, (samples.size, rows * blocks * blocksize)
+        samples = samples.reshape(rows, blocks * blocksize)
     else:
         pytest.skip(f"{dtype} support not implemented")
-    assert samples.shape == (im_size, re_size)
 
     expected = reference.call(samples)
 
@@ -124,24 +148,35 @@ def test_unary(unary_func_name, backend, device, dtype, fpu):
         # However, disabling FTZ in XLA CPU client is effective only for the first
         # part of samples evaluations. To workaround this, we'll evaluate
         # JAX functions blockwise:
-        eval_blocksize = im_size
-        assert re_size < 2**14
-        while eval_blocksize * re_size > 2**14:
+        if complex_plane:
+            eval_blocksize = im_size
+            eval_size = re_size
+        elif real_line:
+            eval_blocksize = rows
+            eval_size = blocks * blocksize
+        else:
+            assert 0, (complex_plane, real_line)  # unreachable
+        orig_eval_blocksize = eval_blocksize
+        assert eval_size < 2**14
+        while eval_blocksize * eval_size > 2**14:
             for p in [2, 3, 5, 7, 11, 13, 17, 19, 23]:
                 if eval_blocksize % p == 0:
                     eval_blocksize //= p
                     break
             else:
                 assert 0  # adjust re/im_size/blocksize parameters to avoid this
-        assert im_size % eval_blocksize == 0, (im_size, eval_blocksize)
+        assert orig_eval_blocksize % eval_blocksize == 0, (orig_eval_blocksize, eval_blocksize)
         result = numpy.concatenate(
-            tuple(func(samples[k * eval_blocksize : (k + 1) * eval_blocksize]) for k in range(im_size // eval_blocksize))
+            tuple(
+                func(samples[k * eval_blocksize : (k + 1) * eval_blocksize])
+                for k in range(orig_eval_blocksize // eval_blocksize)
+            )
         )
     else:
         with register(**register_params):
             result = func(samples)
 
-    if 0:
+    if 0 and complex_plane:
         # for sanity check
         for j in range(im_size):
             for i in range(re_size):
@@ -161,15 +196,28 @@ def test_unary(unary_func_name, backend, device, dtype, fpu):
         print(f"maximal ULP difference: {ulp.max()}")
         return
 
-    bsamples = numpy.zeros((im_blocks, re_blocks), dtype=samples.dtype)
-    bulp = numpy.zeros((im_blocks, re_blocks), dtype=ulp.dtype)
-    for j, blocks in enumerate(numpy.split(ulp, im_blocks, axis=0)):
-        for i, block in enumerate(numpy.split(blocks, re_blocks, axis=1)):
-            samples_block = samples[j * im_blocksize : (j + 1) * im_blocksize, i * re_blocksize : (i + 1) * re_blocksize]
-            ind = numpy.unravel_index(numpy.argmax(block, axis=None), block.shape)
-            assert block[ind[0], ind[1]] == numpy.max(block)
-            bsamples[j, i] = samples_block[ind[0], ind[1]]
-            bulp[j, i] = block[ind[0], ind[1]]
+    if complex_plane:
+        bsamples = numpy.zeros((im_blocks, re_blocks), dtype=samples.dtype)
+        bulp = numpy.zeros((im_blocks, re_blocks), dtype=ulp.dtype)
+        for j, blocks in enumerate(numpy.split(ulp, im_blocks, axis=0)):
+            for i, block in enumerate(numpy.split(blocks, re_blocks, axis=1)):
+                samples_block = samples[j * im_blocksize : (j + 1) * im_blocksize, i * re_blocksize : (i + 1) * re_blocksize]
+                ind = numpy.unravel_index(numpy.argmax(block, axis=None), block.shape)
+                assert block[ind[0], ind[1]] == numpy.max(block)
+                bsamples[j, i] = samples_block[ind[0], ind[1]]
+                bulp[j, i] = block[ind[0], ind[1]]
+    elif real_line:
+        bsamples = numpy.zeros((rows, blocks), dtype=samples.dtype)
+        bulp = numpy.zeros((rows, blocks), dtype=ulp.dtype)
+        for j, blocks_ in enumerate(numpy.split(ulp, rows, axis=0)):
+            for i, block in enumerate(numpy.split(blocks_, blocks, axis=1)):
+                samples_block = samples[j : j + 1, i * blocksize : (i + 1) * blocksize]
+                ind = numpy.unravel_index(numpy.argmax(block, axis=None), block.shape)
+                assert block[ind[0], ind[1]] == numpy.max(block)
+                bsamples[j, i] = samples_block[ind[0], ind[1]]
+                bulp[j, i] = block[ind[0], ind[1]]
+    else:
+        assert 0  # unreachable
     try:
         fa_reference = getattr(fa.utils.numpy_with_algorithms(dtype=dtype), unary_func_name)
     except Exception as msg:
@@ -185,68 +233,114 @@ def test_unary(unary_func_name, backend, device, dtype, fpu):
     timage.fill(0, 10, bulp > max_valid_ulp_count, symbol="!")
     timage.fill(0, 10, bulp > 100 * max_valid_ulp_count, symbol="E")
 
-    real_axis = samples[0:1, ::re_blocksize].real
-    imag_axis = samples[::im_blocksize, 0:1].imag
-    timage.insert(0, 2, fa.TextImage.fromseq(imag_axis))
-    timage.append(-1, 10, fa.TextImage.fromseq(real_axis[:, ::6], mintextwidth=5, maxtextwidth=5))
+    if complex_plane:
+        real_axis = samples[0:1, ::re_blocksize].real
+        imag_axis = samples[::im_blocksize, 0:1].imag
+        timage.insert(0, 2, fa.TextImage.fromseq(imag_axis))
+        timage.append(-1, 10, fa.TextImage.fromseq(real_axis[:, ::6], mintextwidth=5, maxtextwidth=5))
+    elif real_line:
+        laxis = samples[:, 0:1]
+        raxis = samples[:, -1:]
+        timage.insert(0, 2, fa.TextImage.fromseq(laxis))
+        timage.insert(0, blocks + 10 + 5, fa.TextImage.fromseq(raxis), loc="ul")
+    else:
+        assert 0  # unreachable
 
     print()
     print(timage)
     print()
 
+    z = "z" if complex_plane else "x"
     if fa_reference is not None and backend != "algorithms":
-        rows = [
+        table = [
             (
                 "ULP-difference",
-                "z",
-                f"{backend}:{unary_func_name}(z)",
-                f"mpmath:{unary_func_name}(z)",
-                f"numpy:{unary_func_name}(z)",
-                f"fa:{unary_func_name}(z)",
+                z,
+                f"{backend}:{unary_func_name}({z})",
+                f"mpmath:{unary_func_name}({z})",
+                f"numpy:{unary_func_name}({z})",
+                f"fa:{unary_func_name}({z})",
             )
         ]
     else:
-        rows = [
+        table = [
             (
                 "ULP-difference",
-                "z",
-                f"{backend}:{unary_func_name}(z)",
-                f"mpmath:{unary_func_name}(z)",
-                f"numpy:{unary_func_name}(z)",
+                z,
+                f"{backend}:{unary_func_name}({z})",
+                f"mpmath:{unary_func_name}({z})",
+                f"numpy:{unary_func_name}({z})",
             )
         ]
 
     samples = bsamples
     ulp = bulp
 
-    max_rows = 20
-    for value in reversed(sorted(set(ulp.flatten()))):
-        if value <= max_valid_ulp_count:
-            break
-        clusters = fa.utils.Clusters()
-        for re, im in zip(*numpy.where(ulp == value)):
-            clusters.add((re, im))
-        for cluster in clusters.clusters + clusters.split().clusters:
-            re, im = cluster.center_point()
-            with warnings.catch_warnings(action="ignore"):
-                np_value = npy_reference(samples[re, im])
-            with register(**register_params):
-                r = func(samples[re, im])
-            e = reference(samples[re, im])
-            u = fa.utils.diff_ulp(r, e, flush_subnormals=not include_subnormal, equal_nan=True)
-            assert u == value, (u, value, (re, im))
-            if fa_reference is not None:
-                fa_value = fa_reference(samples[re, im])
-                rows.append((value, samples[re, im], r, e, np_value, fa_value))
-            else:
-                rows.append((value, samples[re, im], r, e, np_value))
+    if complex_plane:
+        max_rows = 20
+        for value in reversed(sorted(set(ulp.flatten()))):
+            if value <= max_valid_ulp_count:
+                break
+            clusters = fa.utils.Clusters()
+            for re, im in zip(*numpy.where(ulp == value)):
+                clusters.add((re, im))
+            for cluster in clusters.clusters + clusters.split().clusters:
+                re, im = cluster.center_point()
+                with warnings.catch_warnings(action="ignore"):
+                    np_value = npy_reference(samples[re, im])
+                with register(**register_params):
+                    r = func(samples[re, im])
+                e = reference(samples[re, im])
+                u = fa.utils.diff_ulp(r, e, flush_subnormals=not include_subnormal, equal_nan=True)
+                assert u == value, (u, value, (re, im))
+                if fa_reference is not None:
+                    fa_value = fa_reference(samples[re, im])
+                    table.append((value, samples[re, im], r, e, np_value, fa_value))
+                else:
+                    table.append((value, samples[re, im], r, e, np_value))
 
-    if len(rows) > max_rows:
-        rows = rows[: max_rows // 2] + [(f"...",) * len(rows[0])] + rows[-max_rows // 2 :]
-    col_widths = [max(len(str(row[col])) for row in rows) for col in range(len(rows[0]))]
-    rows.insert(1, tuple("-" * w for w in col_widths))
-    col_fmt = "| " + " | ".join([f"{{{i}:>{w}}}" for i, w in enumerate(col_widths)]) + " |"
-    print("\n".join([col_fmt.format(*map(str, row)) for row in rows]))
+        if len(table) > max_rows:
+            table = table[: max_rows // 2] + [(f"...",) * len(table[0])] + table[-max_rows // 2 :]
+        col_widths = [max(len(str(row[col])) for row in table) for col in range(len(table[0]))]
+        table.insert(1, tuple("-" * w for w in col_widths))
+        col_fmt = "| " + " | ".join([f"{{{i}:>{w}}}" for i, w in enumerate(col_widths)]) + " |"
+        print("\n".join([col_fmt.format(*map(str, row)) for row in table]))
+    elif real_line:
+        max_rows = 20
+        for value in reversed(sorted(set(ulp.flatten()))):
+            if value <= 0:  # max_valid_ulp_count:
+                break
+            clusters = fa.utils.Clusters()
+            for r, s in zip(*numpy.where(ulp == value)):
+                clusters.add((r * 10, s))
+            for cluster in clusters.clusters:
+                r, s = cluster.center_point()
+                r //= 10
+                with warnings.catch_warnings(action="ignore"):
+                    np_value = npy_reference(samples[r, s])
+                with register(**register_params):
+                    res = func(samples[r, s])
+                e = reference(samples[r, s])
+                u = fa.utils.diff_ulp(res, e, flush_subnormals=not include_subnormal, equal_nan=True)
+                assert u == value, (u, value, (r, s))
+                if fa_reference is not None:
+                    fa_value = fa_reference(samples[r, s])
+                    table.append((value, samples[r, s], res, e, np_value, fa_value))
+                else:
+                    table.append((value, samples[r, s], res, e, np_value))
+
+        if len(table) > max_rows:
+            table = (
+                table[: max_rows // 2]
+                + [(f"<snip {len(table) - max_rows} rows>",) + ("...",) * (len(table[0]) - 1)]
+                + table[-max_rows // 2 :]
+            )
+        col_widths = [max(len(str(row[col])) for row in table) for col in range(len(table[0]))]
+        table.insert(1, tuple("-" * w for w in col_widths))
+        col_fmt = "| " + " | ".join([f"{{{i}:>{w}}}" for i, w in enumerate(col_widths)]) + " |"
+        print("\n".join([col_fmt.format(*map(str, row)) for row in table]))
+    else:
+        assert 0  # unreachable
 
     if fpu == "default":
         pytest.xfail("inaccurate or incorrect results")


### PR DESCRIPTION
As in the title.

This enabled discovering that JAX sqrt on CUDA arrays is less accurate that JAX sqrt on CPU arrays.