### PR TITLE
Add RN to fpu.context

### DIFF
--- a/functional_algorithms/algorithms.py
+++ b/functional_algorithms/algorithms.py
@@ -1314,7 +1314,7 @@ def tanh(ctx, z: complex | float):
 @definition("sqrt", domain="real")
 def real_sqrt(ctx, z: float):
     """Square root on real inputs"""
-    return NotImplemented
+    return ctx.sqrt(z)
 
 
 def complex_sqrt_polar(ctx, z: complex):

--- a/functional_algorithms/tests/test_accuracy.py
+++ b/functional_algorithms/tests/test_accuracy.py
@@ -57,6 +57,10 @@ def test_unary(unary_func_name, backend, device, dtype, fpu):
             register_params.update(DAZ=True)
         if "disable-DAZ" in fpu:
             register_params.update(DAZ=False)
+    else:
+        if device == "cpu":
+            register = fa.fpu.context
+            register_params.update(RN="nearest")
 
     numpy_with_backend = getattr(fa.utils, f"numpy_with_{backend}")(device=device, dtype=dtype)
     try:


### PR DESCRIPTION
As in the title.

To test if JAX sqrt platform dependence (see https://github.com/pearu/functional_algorithms/issues/53)  is related to rounding mode (A: it is not).