### PR TITLE
Add `FA_MAX_VALID_ULP_COUNT` env variable to control test_accuracy parameters.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ following math functions:
 - `asinh(z: complex | float)`, using the relation `asinh(z) = -I * asin(z * I)`,
 - `atan(z: complex | float)`, using the relation `atan(z) = -I * atanh(z * I)`,
 - `atanh(z: complex | float)`, using a custom algorithm,
+- `exp(z: complex)`, using `exp(z) = exp(z.real) * (cos(z.imag) + I *
+  sin(z.imag))` with accurate handling of cases when `z.real` is
+  large, or `z.imag` is zero.
 - `hypot(x: float, y: float)` and `absolute(z: complex)`,
 - `log(z: complex)` using a custom algorithm that employs Dekker's product and Fast2Sum algorithm,
 - `log10(z: complex)` using `log10(z) = log(z) / log(10)`,
@@ -58,7 +61,8 @@ states. For instance, the following algorithms are inaccurate on
 specific regions of complex plane when `denormals-are-zeros` bit is
 set:
 
-- `acos`, `acosh`, `asin`, `asinh`, `atan`, `atanh`, `log`, `log2`, `log10`, `log1p`, `sqrt`, `square`,
+- `acos`, `acosh`, `asin`, `asinh`, `atan`, `atanh`, `exp`, `log`,
+  `log2`, `log10`, `log1p`, `sqrt`, `square`,
 
 The following algorithms are inaccurate on specific regions of complex
 plane when `flush-to-zero` bit is set:

--- a/functional_algorithms/algorithms.py
+++ b/functional_algorithms/algorithms.py
@@ -1669,4 +1669,4 @@ def complex_exp(ctx, z: complex):
 
 @definition("exp", domain="real")
 def real_exp(ctx, z: float):
-    return NotImplemented
+    return ctx.exp(z)  # using native exp

--- a/functional_algorithms/tests/test_accuracy.py
+++ b/functional_algorithms/tests/test_accuracy.py
@@ -78,6 +78,8 @@ def test_unary(unary_func_name, backend, device, dtype, fpu):
     extra_prec_multiplier = params["extra_prec_multiplier"]
     samples_limits = params["samples_limits"]
 
+    max_valid_ulp_count = int(os.environ.get("FA_MAX_VALID_ULP_COUNT", max_valid_ulp_count))
+
     # detect the FTZ mode of array backend: if FTZ is enabled, don't
     # generate samples containing subnormals as well as exclude
     # subnormals in comparing results (read: ulp distance between 0

--- a/functional_algorithms/utils.py
+++ b/functional_algorithms/utils.py
@@ -1881,6 +1881,9 @@ def function_validation_parameters(func_name, dtype, device=None):
         max_valid_ulp_count = 4
     elif func_name in {"log", "log10", "log2"}:
         max_valid_ulp_count = 3
+    elif func_name == "exp":
+        max_valid_ulp_count = 3
+        extra_prec_multiplier = 20
     elif func_name in {"atanh", "atan"}:
         extra_prec_multiplier = 20
     elif func_name in {"tanh", "tan"}:


### PR DESCRIPTION
As in the title. Also update docs and and real `exp` to algorithms that uses native `exp` function.