### PR TITLE
Improve efficiency of Expr serialization.

### DIFF
--- a/functional_algorithms/context.py
+++ b/functional_algorithms/context.py
@@ -29,6 +29,7 @@ class Context:
           Parameters dictionary that can be used to parameterize
           algorithms.
         """
+        self._expression_counter = 0
         self._expressions = {}
         self._stack_name = ""
         self._stack_call_count = defaultdict(int)
@@ -74,6 +75,11 @@ class Context:
         # exception.
         prev = self._expressions.get(expr._serialized)
         if prev is None:
+            # each expression is assigned an unique id that is used as
+            # a replacement of operands during serialization
+            expr._serialize_id = self._expression_counter
+            self._expression_counter += 1
+
             prev = self._expressions[expr._serialized] = expr
             # origin is either an empty string (top stack) or a
             # function name modified with an identifier unique to the

--- a/functional_algorithms/typesystem.py
+++ b/functional_algorithms/typesystem.py
@@ -12,6 +12,14 @@ class Type:
         self.kind = kind
         self.param = param
 
+    def __hash__(self):
+        return hash((self.kind, self.param))
+
+    def __eq__(self, other):
+        if isinstance(other, type(self)):
+            return self.context is other.context and self.kind == other.kind and self.param == other.param
+        return False
+
     @property
     def bits(self):
         if self.kind in {"float", "complex", "integer", "boolean"}:


### PR DESCRIPTION
As in the title.

Previously, the byte-size of Expr serialization key could reach to several hundred of millions in certain cases. Now, the byte-size of Expr serialization key is always bounded.