### PR TITLE
Add argument reduction for trigonometric functions

### DIFF
--- a/functional_algorithms/algorithms.py
+++ b/functional_algorithms/algorithms.py
@@ -825,7 +825,7 @@ def fma(ctx, x, y, z):
 
 
 def get_veltkamp_splitter_constant(ctx, largest: float):
-    """Return 2 ** s + 1 where s = ceil(p / 2) and s is the precision of
+    """Return 2 ** s + 1 where s = ceil(p / 2) and p is the precision of
     the floating point number system.
 
     Using `largest` to detect the floating point type: float16,

--- a/functional_algorithms/floating_point_algorithms.py
+++ b/functional_algorithms/floating_point_algorithms.py
@@ -194,10 +194,10 @@ def split_veltkamp(ctx, x, C=None, scale=False):
       abs(x) <= largest / C            otherwise
 
     """
-    one = ctx.constant(1, x)
     if C is None:
         C, N, invN = get_veltkamp_splitter_constants(ctx, get_largest(ctx, x))
-    else:
+    elif scale:
+        one = ctx.constant(1, x)
         N = C - one
         invN = one / N
 
@@ -727,14 +727,14 @@ def fast_polynomial(ctx, x, coeffs, reverse=True, scheme=None, _N=None):
     return a * xd + b
 
 
-def split_tripleword(ctx, x):
+def split_tripleword(ctx, x, scale=False):
     """Split floating-point value to triple-word so that
 
     x == x_hi + x_lo + x_rest
     """
     C1, C2 = get_tripleword_splitter_constants(ctx, get_largest(ctx, x))
-    x_hi, x_mid = split_veltkamp(ctx, x, C1)
-    x_lo, x_rest = split_veltkamp(ctx, x_mid, C2)
+    x_hi, x_mid = split_veltkamp(ctx, x, C1, scale=scale)
+    x_lo, x_rest = split_veltkamp(ctx, x_mid, C2, scale=scale)
     return x_hi, x_lo, x_rest
 
 

--- a/functional_algorithms/floating_point_algorithms.py
+++ b/functional_algorithms/floating_point_algorithms.py
@@ -736,7 +736,7 @@ def split_tripleword(ctx, x, scale=False):
     """
     C1, C2 = get_tripleword_splitter_constants(ctx, get_largest(ctx, x))
     x_hi, x_mid = split_veltkamp(ctx, x, C1, scale=scale)
-    x_lo, x_rest = split_veltkamp(ctx, x_mid, C2, scale=False)
+    x_lo, x_rest = split_veltkamp(ctx, x_mid, C2, scale=scale)
     return x_hi, x_lo, x_rest
 
 
@@ -817,16 +817,19 @@ def mw2dw(ctx, x):
 
 
 def argument_reduction_trigonometric(ctx, x):
-    """Return k, r such that
+    """Return k, r, t such that
 
-      x = 2 * pi * N + k * pi / 2 +  r
+      x = 2 * pi * N + k * pi / 2 + r + t
 
-    where N is some integral, k is in {0, 1, 2, 3}, and abs(r) < pi / 2.
+    where N is some integral, k is in {0, 1, 2, 3}, and abs(r) < pi / 4.
 
     Reference:
       https://userpages.cs.umbc.edu/phatak/645/supl/Ng-ArgReduction.pdf
     """
     import numpy
+
+    if isinstance(x, (numpy.float64, numpy.float32, numpy.float16)):
+        return argument_reduction_trigonometric_impl(ctx, type(x), x)
 
     largest = get_largest(ctx, x)
     fp64_k, fp64_r, fp64_t = argument_reduction_trigonometric_impl(ctx, numpy.float64, x)

--- a/functional_algorithms/tests/test_floating_point_algorithms.py
+++ b/functional_algorithms/tests/test_floating_point_algorithms.py
@@ -659,3 +659,72 @@ def test_split_tripleword(dtype):
         pl = len(bl)
         pr = len(br)
         assert ph + pl + pr <= p
+
+
+def test_argument_reduction_trigonometric(dtype):
+    import mpmath
+
+    print()
+    ctx = NumpyContext()
+    fi = numpy.finfo(dtype)
+    min_value = fi.smallest_normal
+    max_value = fi.max
+
+    largest = fpa.get_largest(ctx, dtype(0))
+    max_x = largest / dtype(2 ** {numpy.float64: 18, numpy.float32: 5, numpy.float16: 2}[dtype])
+
+    max_prec = {numpy.float16: 24, numpy.float32: 149, numpy.float64: 1074}[dtype]
+
+    if dtype == numpy.float64:
+        x = numpy.ldexp(6381956970095103, 797)
+        k, r, t = fpa.argument_reduction_trigonometric(ctx, x)  # 4.687165924254629e-19
+        # ulp difference from dtype(4.687165924254624e-19) is 5. Is
+        # the reference value from
+        # https://userpages.cs.umbc.edu/phatak/645/supl/Ng-ArgReduction.pdf
+        # wrong?
+        u = utils.diff_ulp(r + t, dtype(4.687165924254624e-19))
+        assert u <= 5, (r, t, r + t)
+
+    size = 1000
+    samples = utils.real_samples(size, dtype=dtype, min_value=min_value, max_value=max_x)
+    ulp_counts = defaultdict(int)
+    for x in samples:
+        assert isinstance(x, dtype)
+        k, r, t = fpa.argument_reduction_trigonometric(ctx, x)
+
+        assert k in [0, 1, 2, 3], x
+        assert abs(r) <= dtype(numpy.pi / 4) * 1.1, (r, k, x)
+        assert isinstance(r, dtype)
+
+        mp_ctx = mpmath.mp
+        with mp_ctx.workprec(max_prec * 10):
+            x_mp = utils.float2mpf(mp_ctx, x)
+            y_mp = x_mp * (2 / mp_ctx.pi)
+            Nk = mp_ctx.floor(y_mp)
+
+            expected_r1 = utils.mpf2float(dtype, (y_mp - Nk) * (mp_ctx.pi / 2))
+            expected_k1 = utils.mpf2float(dtype, Nk % 4)
+
+            expected_r2 = utils.mpf2float(dtype, (y_mp - (Nk + 1)) * (mp_ctx.pi / 2))
+            expected_k2 = utils.mpf2float(dtype, (Nk + 1) % 4)
+
+            u_r1 = utils.diff_ulp(r + t, expected_r1)
+            u_r2 = utils.diff_ulp(r + t, expected_r2)
+            u_r = min(u_r1, u_r2)
+            if u_r == u_r1:
+                expected_r = expected_r1
+                expected_k = expected_k1
+            else:
+                expected_r = expected_r2
+                expected_k = expected_k2
+
+            ulp_counts[u_r] += 1
+
+            assert k == expected_k
+            if dtype == numpy.float16:
+                assert r == expected_r or u_r <= 10
+            else:
+                assert r == expected_r or u_r <= 1
+
+    for u in sorted(ulp_counts):
+        print(f"ULP difference {u}: {ulp_counts[u]}")

--- a/functional_algorithms/tests/test_floating_point_algorithms.py
+++ b/functional_algorithms/tests/test_floating_point_algorithms.py
@@ -634,13 +634,19 @@ def test_argument_reduction_exponent(dtype):
 
 
 def test_split_tripleword(dtype):
-    np_ctx = NumpyContext()
+    ctx = NumpyContext()
     p = utils.get_precision(dtype)
     min_x = {numpy.float16: -986.0, numpy.float32: -7.51e33, numpy.float64: -4.33e299}[dtype]
     max_x = {numpy.float16: 1007.0, numpy.float32: 8.3e34, numpy.float64: 1.33e300}[dtype]
+
+    largest = fpa.get_largest(ctx, dtype(0))
+    C1 = fpa.get_tripleword_splitter_constants(ctx, largest)[0]
+    max_x = largest * dtype(1 - 1 / C1)
+    min_x = -max_x
+
     size = 1000
     for x in utils.real_samples(size, dtype=dtype, min_value=min_x, max_value=max_x):
-        xh, xl, xr = fpa.split_tripleword(np_ctx, x)
+        xh, xl, xr = fpa.split_tripleword(ctx, x, scale=True)
         assert x == xh + xl + xr
 
         bh = utils.tobinary(xh).split("p")[0].lstrip("-")

--- a/functional_algorithms/utils.py
+++ b/functional_algorithms/utils.py
@@ -2157,11 +2157,41 @@ class NumpyContext:
             if isinstance(value, str):
                 if value == "largest":
                     return numpy.finfo(dtype).max
+                if value == "pi":
+                    return numpy.pi
                 assert 0, (value, dtype)  # not implemented
             return dtype(value)
-        assert 0, (value, like)  # unreachable
+        assert 0, (value, like, type(like))  # unreachable
 
     def floor(self, value):
         if isinstance(value, numpy.floating):
             return numpy.floor(value)
         assert 0, (value, type(value))  # unreachable
+
+    def trunc(self, value):
+        if isinstance(value, numpy.floating):
+            return numpy.trunc(value)
+        assert 0, (value, type(value))  # unreachable
+
+    def round(self, value):
+        if isinstance(value, numpy.floating):
+            return numpy.round(value)
+        assert 0, (value, type(value))  # unreachable
+
+
+def get_pi_over_two_multiword(dtype, prec=None, max_length=None):
+    if prec is None:
+        prec = {numpy.float16: 4, numpy.float32: 11, numpy.float64: 20}[dtype]
+    max_prec = {numpy.float16: 24, numpy.float32: 149, numpy.float64: 1074}[dtype]
+    ctx = mpmath.mp
+    with ctx.workprec(max_prec):
+        return mpf2multiword(dtype, ctx.pi / 2, p=prec, max_length=max_length)
+
+
+def get_two_over_pi_multiword(dtype, prec=None, max_length=None):
+    if prec is None:
+        prec = {numpy.float16: 4, numpy.float32: 10, numpy.float64: 20}[dtype]
+    max_prec = {numpy.float16: 24, numpy.float32: 149, numpy.float64: 1074}[dtype]
+    ctx = mpmath.mp
+    with ctx.workprec(max_prec):
+        return mpf2multiword(dtype, 2 / ctx.pi, p=prec, max_length=max_length)


### PR DESCRIPTION
This PR adds:
- `split_tripleword(x) -> xh, xl, xr` such that `xh + xl + xr == x`
- `multiword2mpf(mw) -> mpf`
- `mul_mw`, `mul_mw_mod4` to multiply two multi-words
- `argument_reduction_trigonometric(x) -> k, r, t` such that `x = 2 * pi * N + k * pi / 2 + r + t` where `N` is integral, `k` in `{0, 1, 2, 3}` and `abs(r + t) < pi / 4`