### PR TITLE
Add FP expansion operations: multiply, square, sqrt, reciprocal, add.

### DIFF
--- a/functional_algorithms/apmath.py
+++ b/functional_algorithms/apmath.py
@@ -30,19 +30,31 @@ Popescu. Formal Verification of a FloatingPoint Expansion
 Renormalization Algorithm. 8th International Conference on Interactive
 Theorem Proving (ITP’2017), Sep 2017, Brasilia, Brazil.
 https://hal.science/hal-01512417
+
+7. Mioara Joldes, Olivier Marty, Jean-Michel Muller, Valentina
+Popescu. Arithmetic algorithms for extended precision using
+floating-point expansions. IEEE Transactions on Computers, 2016, 65
+(4), pp.1197 - 1210. ff10.1109/TC.2015.2441714ff. ffhal-01111551v2
+https://hal.science/hal-01111551v2
+
+8. Nicolas Brisebarre, Guillaume Hanrot, Jean-Michel Muller, Paul
+Zimmermann. Correctly-rounded evaluation of a function: why, how, and
+at what cost?. 2025. �hal-04474530v3� HAL Id: hal-04474530
+https://hal.science/hal-04474530v3
+
 """
 
 from . import floating_point_algorithms as fpa
 
 
-def _merge(ctx, x, y):
+def _merge(ctx, x, y, cmp):
     if not x:
         return y
     if not y:
         return x
-    f = ctx.lt(x[0], y[0])
-    r1 = _merge(ctx, x[1:], y)
-    r2 = _merge(ctx, x, y[1:])
+    f = cmp(ctx, x[0], y[0])
+    r1 = _merge(ctx, x[1:], y, cmp)
+    r2 = _merge(ctx, x, y[1:], cmp)
     assert len(r1) == len(r2)
     lst = [ctx.select(f, x[0], y[0])]
     for a, b in zip(r1, r2):
@@ -50,12 +62,22 @@ def _merge(ctx, x, y):
     return lst
 
 
-def mergesort(ctx, lst):
+def mergesort(ctx, lst, mth="<"):
     """Return a sorted list of expressions using mergesort method."""
     if len(lst) < 2:
         return lst
     n = len(lst) // 2
-    return _merge(ctx, mergesort(ctx, lst[:n]), mergesort(ctx, lst[n:]))
+    if mth == "<":
+        cmp = lambda ctx, x, y: ctx.lt(x, y)
+    elif mth == "a<a":
+        cmp = lambda ctx, x, y: ctx.lt(abs(x), abs(y))
+    if mth == ">":
+        cmp = lambda ctx, x, y: ctx.lt(y, x)
+    elif mth == "a>a":
+        cmp = lambda ctx, x, y: ctx.lt(abs(y), abs(x))
+    else:
+        raise NotImplementedError(f"comparison method '{mth}'")
+    return _merge(ctx, mergesort(ctx, lst[:n], mth=mth), mergesort(ctx, lst[n:], mth), cmp=cmp)
 
 
 def two_sum(ctx, a, b):
@@ -74,15 +96,44 @@ def two_prod(ctx, a, b):
     return fpa.mul_dekker(ctx, a, b)
 
 
-def renormalize(ctx, seq, functional=False, fast=False):
+def vecsum(ctx, seq, fast=False):
+    """ """
+    s = seq[-1]
+    e_lst = []
+    for i in reversed(range(len(seq) - 1)):
+        if fast:
+            s, e = quick_two_sum(ctx, seq[i], s)
+        else:
+            s, e = two_sum(ctx, seq[i], s)
+        e_lst.insert(0, e)
+    e_lst.insert(0, s)
+    return e_lst
+
+
+def vecsumerr(ctx, seq, fast=False):
+    """ """
+    g_lst = []
+    s = seq[0]
+    for i in range(len(seq) - 1):
+        if fast:
+            g_i, s = quick_two_sum(ctx, s, seq[i + 1])
+        else:
+            g_i, s = two_sum(ctx, s, seq[i + 1])
+        g_lst.append(g_i)
+    g_lst.append(s)
+    return g_lst
+
+
+def renormalize(ctx, seq, functional=False, fast=False, size=None):
     """Convert a list of possibly overlapping items to a list of
     non-overlapping items.
 
     The renormalization algorithm originates from Priest's PhD thesis
-    (1992) and there exists different modifications of it. Here, we'll
+    (1992) and there exists several modifications of it. Here we'll
     use the renormalization algorithm from
     https://hal.science/hal-01512417 that is provided with a formal
-    proof and is slightly simpler from other modifications.
+    proof and is more efficient as it proved that that the third step
+    of the algorithm in ffhal-01111551v2 is unnecessary.
 
     Absolute values of the input must be a decreasing sequence,
     excluding zero items. If the input does not satisfy this criteria,
@@ -97,20 +148,15 @@ def renormalize(ctx, seq, functional=False, fast=False):
     The length of the output is equal or less than the length of the
     input. If functional is True, the lengths of input and output are
     equal and output may contain zero items.
+
+    The length of the output will not exceed size when specified.
     """
     # VecSum:
-    s = seq[-1]
-    zero = ctx.constant(0, s)
-    e_lst = []
-    for i in reversed(range(len(seq) - 1)):
-        if fast:
-            s, e = quick_two_sum(ctx, seq[i], s)
-        else:
-            s, e = two_sum(ctx, seq[i], s)
-        e_lst.insert(0, e)
-    e_lst.insert(0, s)
+    e_lst = vecsum(ctx, seq, fast=fast)
 
     # VecSumErrBranch:
+    if functional:
+        zero = ctx.constant(0, seq[0])
     f_lst = []
     eps_i = e_lst[0]
     for i in range(len(seq) - 1):
@@ -132,4 +178,122 @@ def renormalize(ctx, seq, functional=False, fast=False):
         f_lst.append(ctx.select(p, eps_i, zero))
     elif ctx._is_nonzero(eps_i):
         f_lst.append(eps_i)
+    if size is not None:
+        return f_lst[:size]
     return f_lst
+
+
+def negate(ctx, seq):
+    """Negate an FP expansion."""
+    return [-x for x in seq]
+
+
+def add(ctx, seq1, seq2, functional=False, fast=False, size=None):
+    """Add two FP expansions."""
+    return renormalize(ctx, seq1 + seq2, functional=functional, fast=fast, size=size)
+
+
+def subtract(ctx, seq1, seq2, functional=False, fast=False, size=None):
+    """Subtract two FP expansions."""
+    return renormalize(ctx, seq1 + negate(ctx, seq2), functional=functional, fast=fast, size=size)
+
+
+def multiply(ctx, seq1, seq2, functional=False, fast=False, size=None):
+    """Multiply two FP expansions.
+
+    Warning: when fast=True, the result will be very likely inaccurate.
+    """
+    r_0, e_0 = two_prod(ctx, seq1[0], seq2[0])
+    r_lst = [r_0]
+    e_lst = [e_0]
+    for n in range(1, len(seq1) + len(seq2)):
+        p_lst = []
+        ne_lst = []
+        for i1 in range(len(seq1)):
+            for i2 in range(len(seq2)):
+                if i1 + i2 == n:
+                    p_i, e_i = two_prod(ctx, seq1[i1], seq2[i2])
+                    p_lst.append(p_i)
+                    ne_lst.append(e_i)
+        lst = vecsum(ctx, p_lst + e_lst, fast=fast)
+        r_lst.append(lst[0])
+        e_lst = lst[1:] + ne_lst
+    lst = r_lst + e_lst
+    return renormalize(ctx, lst, functional=functional, fast=fast, size=size)
+
+
+def square(ctx, seq, functional=False, fast=False, size=None):
+    """Square of an FP expansion.
+
+    (x0 + x1 + x2) ** 2
+      = x0 ** 2 + 2 * x0 * x1 + (x1 ** 2 + 2 * x0 * x2) + 2 * x1 * x2 + x2 ** 2
+    """
+    r_0, e_0 = two_prod(ctx, seq[0], seq[0])
+    r_lst = [r_0]
+    e_lst = [e_0]
+    for n in range(1, len(seq) * 2):
+        p_lst = []
+        ne_lst = []
+        for i1 in range(len(seq)):
+            i2 = n - i1
+            if i1 > i2:
+                continue
+            elif i1 < i2:
+                p_i, e_i = two_prod(ctx, seq[i1], seq[i2])
+                p_i += p_i
+                e_i += e_i
+            else:
+                p_i, e_i = two_prod(ctx, seq[i1], seq[i1])
+            p_lst.append(p_i)
+            ne_lst.append(e_i)
+        lst = vecsum(ctx, p_lst + e_lst, fast=fast)  # should fast be always False?
+        r_lst.append(lst[0])
+        e_lst = lst[1:] + ne_lst
+    return renormalize(ctx, r_lst + e_lst, functional=functional, fast=fast, size=size)
+
+
+def reciprocal(ctx, seq, functional=False, size=None):
+    """Reciprocal of an FP expansion.
+
+    The size of the output FP expansion must be a power of two.
+    """
+    if size is None:
+        size = len(seq)
+
+    q = size.bit_length() - 1
+    assert 2**q == size
+
+    two = ctx.constant(2, seq[0])
+    x_lst = [ctx.reciprocal(seq[0])]
+    for i in range(0, q):
+        v_lst = multiply(ctx, x_lst, seq[: 2 ** (i + 1)], functional=functional, size=2 ** (i + 1))
+        w_lst = subtract(ctx, [two], v_lst, functional=functional, size=2 ** (i + 1))
+        x_lst = multiply(ctx, x_lst, w_lst, functional=functional, size=2 ** (i + 1))
+
+    assert len(x_lst) == size
+    return x_lst
+
+
+def sqrt(ctx, seq, functional=False, size=None):
+    """Square root of an FP expansion.
+
+    The size of the output FP expansion must be a power of two.
+    """
+    if size is None:
+        size = len(seq)
+
+    q = size.bit_length() - 1
+    assert 2**q == size
+
+    three = ctx.constant(3, seq[0])
+    half = ctx.constant(0.5, seq[0])
+    x_lst = [ctx.sqrt(seq[0])]
+    for i in range(0, q):
+        v_lst = multiply(ctx, x_lst, seq[: 2 ** (i + 1)], functional=functional, size=2 ** (i + 1))
+        w_lst = multiply(ctx, x_lst, v_lst, functional=functional, size=2 ** (i + 1))
+        y_lst = subtract(ctx, [three], v_lst, functional=functional, size=2 ** (i + 1))
+        z_lst = multiply(ctx, x_lst, y_lst, functional=functional, size=2 ** (i + 1))
+        x_lst = [z * half for z in z_lst]
+
+    assert len(x_lst) == size
+    return x_lst

--- a/functional_algorithms/tests/test_utils.py
+++ b/functional_algorithms/tests/test_utils.py
@@ -717,3 +717,22 @@ def test_overlapping(real_dtype):
         assert utils.overlapping(y1, x1)
         assert y1 + y2 == y1
         assert x + x1 == y1
+
+
+def test_float2fraction(real_dtype):
+    import mpmath
+
+    if real_dtype == numpy.longdouble:
+        pytest.skip(f"support not implemented")
+
+    prec = {numpy.float16: 11, numpy.float32: 24, numpy.float64: 53}[real_dtype]
+
+    mp_ctx = mpmath.mp
+    for x in utils.real_samples(10_000, dtype=real_dtype, include_subnormal=True):
+        q = utils.float2fraction(x)
+        r = utils.fraction2float(real_dtype, q)
+        assert x == r
+        with mp_ctx.workprec(prec):
+            m = utils.float2mpf(mp_ctx, x)
+            f = utils.float2fraction(m)
+        assert f == q

--- a/functional_algorithms/utils.py
+++ b/functional_algorithms/utils.py
@@ -1,4 +1,5 @@
 import contextlib
+import fractions
 import itertools
 import numpy
 import math
@@ -53,8 +54,12 @@ def float2mpf(ctx, x):
     elif numpy.isfinite(x):
         prec, rounding = ctx._prec_rounding
         mantissa, exponent = numpy.frexp(x)
-        man = int(mpmath.ldexp(mantissa, prec))
-        exp = int(exponent - prec)
+        man_ = ctx.ldexp(mantissa, prec)
+        man = int(man_)
+        assert man == man_
+        exp_ = exponent - prec
+        exp = int(exp_)
+        assert exp == exp_
         r = ctx.make_mpf(mpmath.libmp.from_man_exp(man, exp, prec, rounding))
         assert ctx.isfinite(r), r._mpf_
         return r
@@ -70,11 +75,14 @@ def mpf2float(dtype, x, flush_subnormals=False, prec=None, rounding=None):
     """
     ctx = x.context
     if ctx.isfinite(x):
-        prec_rounding = ctx._prec_rounding
+        prec_rounding = ctx._prec_rounding[:]
         if prec is not None:
             prec_rounding[0] = prec
+        else:
+            prec_rounding[0] = get_precision(dtype)
         if rounding is not None:
             prec_rounding[1] = rounding
+
         sign, man, exp, bc = mpmath.libmp.normalize(*x._mpf_, *prec_rounding)
         assert bc >= 0, (sign, man, exp, bc, x._mpf_)
         fp_format = dtype.__name__
@@ -202,6 +210,92 @@ def float2bin(f):
     if significant_bits:
         return f"{sign}1.{significant_bits}p{e:+01d}"
     return f"{sign}1p{e:+01d}"
+
+
+def float2fraction(f):
+    """Convert floating-point number to Fraction.
+    The conversion is exact.
+    """
+    if isinstance(f, list):
+        return sum(map(float2fraction, f))
+    elif isinstance(f, numpy.floating):
+        dtype = type(f)
+        fi = numpy.finfo(dtype)
+        itype = {numpy.float16: numpy.uint16, numpy.float32: numpy.uint32, numpy.float64: numpy.uint64}[dtype]
+        i = f.view(itype)
+        one = itype(1)
+        ssz = 1  # bit-size of sign part
+        esz = itype(fi.nexp)  # bit-size of exponential part
+        fsz = itype(-1 - fi.negep)  # bit-size of fractional part
+        fmask = itype((one << fsz) - one)
+        emask = itype((one << esz) - one)
+        umask = itype((one << (esz + fsz)) - one)
+        mxu = int(one << fsz)
+
+        u = i & umask
+
+        fpart = int(u & fmask)
+        epart = int((u >> fsz) & emask)
+        s = 1 if f < 0 else 0
+        e = epart + fi.minexp - 1
+
+        if epart == 0 and fpart == 0:
+            # signed zero
+            num = 0
+            denom = 1 - 2 * s
+        elif epart == 0:
+            # subnormals
+            num = (1 - 2 * s) * (fpart)
+            denom = mxu * (1 << (-e - 1))
+        elif epart == emask and fpart == 0:
+            # infinity
+            num = (1 - 2 * s) * (1 << fi.maxexp)
+            denom = 1
+        elif e < 0:
+            num = (1 - 2 * s) * (mxu + fpart)
+            denom = mxu * (1 << (-e))
+        else:
+            num = (1 - 2 * s) * (mxu + fpart) * (1 << e)
+            denom = mxu
+        return fractions.Fraction(num, denom)
+    elif isinstance(f, float):
+        return float2fraction(numpy.float64(f))
+    elif isinstance(f, mpmath.mpf):
+        sign, man, exp, bc = f._mpf_
+        if man == 0 and exp == 0:
+            num = (1 - 2 * sign) * 0
+            denom = 1
+        elif man == 0:
+            # infinity
+            k = 1
+            while 2**k < f.context.prec:
+                k += 1
+            maxexp = 2 ** (3 * k - 8)  # k=4->16, 5->128, 6->1024
+            num = (1 - 2 * sign) * (2**maxexp)
+            denom = 1
+        elif exp < 0:
+            num = man * (1 - 2 * sign)
+            denom = 2 ** (-exp)
+        else:
+            num = man * 2 ** (exp) * (1 - 2 * sign)
+            denom = 1
+        return fractions.Fraction(num, denom)
+    raise TypeError(f"float to fraction conversion requires floating-point input, got {type(f).__name__}")
+
+
+def fraction2float(dtype, q):
+    """Convert Fraction to a floating-point number.
+    The conversion may be inexact.
+    """
+    fi = numpy.finfo(dtype)
+    num, denom = q.numerator, q.denominator
+    unum = abs(num)
+    if num == 0:
+        return dtype(0) if denom == 1 else -dtype(0)
+    elif denom == 1 and unum >= (1 << fi.maxexp):
+        return -dtype(numpy.inf) if num < 0 else dtype(numpy.inf)
+    else:
+        return dtype(num / denom)
 
 
 def get_precision(x):
@@ -1326,33 +1420,70 @@ def real_samples(
     else:
         max_value = dtype(max_value)
 
+    if not include_subnormal:
+        if min_value != 0 and abs(min_value) < min_pos_value:
+            if min_value < 0:
+                min_value = -dtype(min_pos_value)
+            else:
+                min_value = dtype(0)
+
+        if max_value != 0 and abs(max_value) < min_pos_value:
+            if max_value < 0:
+                max_value = -dtype(0)
+            else:
+                max_value = dtype(min_pos_value)
+
+    if min_value == max_value:
+        return numpy.array([min_value], dtype=dtype)
+
     if min_value >= max_value:
         raise ValueError(f"minimal value (={min_value}) cannot be greater than maximal value (={max_value})")
 
     if user_specified_bounds:
-        if min_value >= 0:
+        if min_value >= dtype(0):
             start, end = min_value.view(utype), max_value.view(utype)
             step = int(end - start)
             r = (start + numpy.array([i // (num - 1) for i in range(0, num * step, step)], dtype=utype)).view(dtype)
             assert r.size == num
-            return numpy.unique(r) if unique else r
-        if max_value < 0:
+        elif max_value <= -dtype(0):
             start, end = max_value.view(utype), min_value.view(utype)
             step = int(end - start)
             r = (start + numpy.array([i // (num - 1) for i in range(0, num * step, step)], dtype=utype)).view(dtype)
             assert r.size == num
-            return numpy.unique(r[::-1]) if unique else r[::-1]
-        neg_diff = diff_ulp(abs(min_value), min_pos_value)
-        pos_diff = diff_ulp(abs(max_value), min_pos_value)
-        neg_num = int(neg_diff * num / (neg_diff + pos_diff))
-        pos_num = num - neg_num - int(bool(include_zero))
-
-        neg_part = real_samples(size=neg_num, dtype=dtype, min_value=min_value, max_value=-min_pos_value)
-        pos_part = real_samples(size=pos_num, dtype=dtype, min_value=min_pos_value, max_value=max_value)
-        if include_zero:
-            r = numpy.concatenate([neg_part, numpy.array([0], dtype=dtype), pos_part])
+            r = r[::-1]
         else:
-            r = numpy.concatenate([neg_part, pos_part])
+            neg_diff = diff_ulp(abs(min_value), min_pos_value)
+            pos_diff = diff_ulp(abs(max_value), min_pos_value)
+            neg_num = int(neg_diff * num / max(1, neg_diff + pos_diff))
+            pos_num = num - neg_num - int(bool(include_zero))
+
+            neg_part = real_samples(
+                size=neg_num,
+                dtype=dtype,
+                include_subnormal=include_subnormal,
+                min_value=min_value,
+                max_value=-min_pos_value if min_value < -min_pos_value else -dtype(0),
+            )
+            pos_part = real_samples(
+                size=pos_num,
+                dtype=dtype,
+                include_subnormal=include_subnormal,
+                min_value=min_pos_value if min_pos_value < max_value else dtype(0),
+                max_value=max_value,
+            )
+            if include_zero:
+                r = numpy.concatenate([neg_part, numpy.array([0], dtype=dtype), pos_part])
+            else:
+                r = numpy.concatenate([neg_part, pos_part])
+        if not include_subnormal:
+            for i in range(len(r)):
+                if r[i] == 0:
+                    continue
+                if abs(r[i]) < fi.smallest_normal:
+                    if r[i] < 0:
+                        r[i] = -dtype(0)
+                    else:
+                        r[i] = dtype(0)
         return numpy.unique(r) if unique else r
     if 1:
         # The following method gives a sample distibution that is
@@ -1603,6 +1734,110 @@ def complex_pair_samples(
     return s1, s2
 
 
+def expansion_samples(
+    size=None,
+    length=2,
+    overlapping=False,
+    dtype=numpy.float32,
+    min_value=None,
+    max_value=None,
+    include_subnormal=False,
+    nonnegative=False,
+):
+    """Return a list of FP expansion samples.
+
+    A FP expansion is a list of floating-point values with specified
+    overlapping property.
+
+    Parameters
+    ----------
+    size : int
+      Initial size of the samples array. A minimum value is 6 ** length.
+    length : int
+      The length of an FP expansion.
+    dtype:
+      Floating-point type: float16, float32, float64.
+    include_subnormal: bool
+      When True, samples include subnormal numbers.
+    nonnegative: bool
+      When True, finite samples are all non-negative.
+
+    """
+    if size is None:
+        size = 6**length
+    assert length > 0
+    if length == 1:
+        return [
+            [x_]
+            for x_ in real_samples(
+                size,
+                dtype=dtype,
+                include_infinity=False,
+                include_huge=False,
+                include_subnormal=include_subnormal,
+                nonnegative=nonnegative,
+                min_value=min_value,
+                max_value=max_value,
+            )
+        ]
+
+    size1 = max(6, 2 ** int(math.log2(size) / length))
+    size2 = max(6 ** (length - 1), int(size // size1 + 1))
+    fi = numpy.finfo(dtype)
+    c1 = numpy.ldexp(dtype(1), fi.negep + 1)
+    c6 = numpy.ldexp(dtype(1), fi.negep + 6)
+    c = numpy.ldexp(dtype(1), fi.negep)
+    lst = []
+    for x in expansion_samples(
+        size=size1,
+        length=1,
+        overlapping=overlapping,
+        dtype=dtype,
+        include_subnormal=include_subnormal,
+        nonnegative=nonnegative,
+        min_value=min_value,
+        max_value=max_value,
+    ):
+        if overlapping:
+            inner_lst = expansion_samples(
+                size=size2 // 2 + 1,
+                length=length - 1,
+                overlapping=overlapping,
+                dtype=dtype,
+                include_subnormal=include_subnormal,
+                nonnegative=nonnegative,
+                min_value=-abs(x[0]) * c6,
+                max_value=-abs(x[0]) * c1,
+            ) + expansion_samples(
+                size=size2 // 2 + 1,
+                length=length - 1,
+                overlapping=overlapping,
+                dtype=dtype,
+                include_subnormal=include_subnormal,
+                nonnegative=nonnegative,
+                min_value=abs(x[0]) * c1,
+                max_value=abs(x[0]) * c6,
+            )
+        else:
+            inner_lst = expansion_samples(
+                size=size2,
+                length=length - 1,
+                overlapping=overlapping,
+                dtype=dtype,
+                include_subnormal=include_subnormal,
+                nonnegative=nonnegative,
+                min_value=-abs(x[0]) * c,
+                max_value=abs(x[0]) * c,
+            )
+        for y in inner_lst:
+            e = x + y
+            with warnings.catch_warnings(action="ignore"):
+                s = sum(e[:1], e[-1])
+            if numpy.isfinite(s):
+                lst.append(e)
+    return lst
+
+
 def iscomplex(value):
     return isinstance(value, (complex, numpy.complexfloating))
 
@@ -1632,6 +1867,15 @@ def diff_ulp(x, y, flush_subnormals=UNSPECIFIED, equal_nan=False) -> int:
     When equal_nan is set to True, ULP difference between nan values
     of both quiet and signaling kinds is defined as 0.
     """
+    if isinstance(x, list) and isinstance(y, list):
+        if len(x) < len(y):
+            x = x + [type(x[0])(0)] * (len(y) - len(x))
+        elif len(x) > len(y):
+            y = y + [type(y[0])(0)] * (len(x) - len(y))
+        u = 0
+        for x_, y_ in zip(x, y):
+            u += diff_ulp(x_, y_, flush_subnormals=flush_subnormals, equal_nan=equal_nan)
+        return u
     if isinstance(x, numpy.floating):
         uint = {numpy.float64: numpy.uint64, numpy.float32: numpy.uint32, numpy.float16: numpy.uint16}[x.dtype.type]
         sx = -1 if x < 0 else (1 if x > 0 else 0)
@@ -2056,6 +2300,42 @@ class Clusters:
         return result
 
 
+def expansion2mpf(ctx, e):
+    """Transform FP expansion to mpf instance."""
+    return sum([float2mpf(ctx, e_) for e_ in reversed(e[:-1])], float2mpf(ctx, e[-1]))
+
+
+def mpf2expansion(dtype, x):
+    """Transform mpf instance to an FP expansion."""
+    lst = []
+    prev_x = 0
+    while True:
+        y = mpf2float(dtype, x)
+        if y == 0:
+            break
+        lst.append(y)
+        x = x - float2mpf(x.context, y)
+    return lst or [dtype(0)]
+
+
+def fraction2expansion(dtype, q, length=2):
+    """Transform a fraction to an FP expansion.
+
+    If the length of output is smaller than the specified length then
+    the conversion is exact.
+
+    The output may require renormalization.
+    """
+    lst = []
+    for i in range(length):
+        f = fraction2float(dtype, q)
+        if f == dtype(0):
+            break
+        lst.append(f)
+        q = q - float2fraction(f)
+    return lst
+
+
 def multiword2mpf(ctx, mw):
     """Transform multiword to mpf instance."""
     s = float2mpf(ctx, mw[-1])
@@ -2171,6 +2451,11 @@ class NumpyContext:
     def ne(self, x, y):
         if isinstance(x, numpy.floating) or isinstance(y, numpy.floating):
             return x != y
+        assert 0, (x, y, type(x))  # unreachable
+
+    def lt(self, x, y):
+        if isinstance(x, numpy.floating) or isinstance(y, numpy.floating):
+            return x < y
         assert 0, (x, y, type(x))  # unreachable
 
     def floor(self, value):

--- a/functional_algorithms/utils.py
+++ b/functional_algorithms/utils.py
@@ -2564,8 +2564,13 @@ def show_prec(prec, title=None):
             print(f"  precision {u}: {prec[u]}")
         elif i == len(lst) - 5:
             rest += prec[u]
-            print(f"  precision in [{u}..{u5}]: {rest}")
-            rest = []
+            if u5 is None:
+                u5 = u
+            if u5 == u:
+                print(f"  precision {u}: {rest}")
+            else:
+                print(f"  precision in [{u}..{u5}]: {rest}")
+            rest = 0
         elif i > len(lst) - 5:
             print(f"  precision {u}: {prec[u]}")
         else:


### PR DESCRIPTION
As in the title.

Also, this PR adds
- apmath functions `subtract`, `negate`, `rsqrt`,
- apmath utility functions `vecsum`, `vecsumerr`, `move_zeros_to_right`
- utility functions `diff_prec`, `float2fraction`, `fraction2float`, `expansion_samples`, `expansion2mpf`, `mpf2expansion`, `fraction2expansion`, and `show_prec`