### PR TITLE
Add FMA algorithm

### DIFF
--- a/functional_algorithms/apmath_algorithms.py
+++ b/functional_algorithms/apmath_algorithms.py
@@ -1,5 +1,10 @@
 from . import algorithms as faa
+from . import floating_point_algorithms as fpa
 from . import apmath
+
+expansion: type = list[float | complex, ...]
+fexpansion: type = list[float, ...]
+cexpansion: type = list[complex, ...]
 
 
 class definition(faa.definition):
@@ -7,12 +12,109 @@ class definition(faa.definition):
 
 
 @definition("square", domain="real")
-def real_square(ctx, x: list[float, ...], functional: bool = True, size: int = None):
+def real_square(ctx, x: fexpansion, functional: bool = True, size: int = None):
     """Square on real input: x * x"""
     return apmath.square(ctx, x, functional=functional, size=2)
 
 
 @definition("square")
-def square(ctx, z: list[float | complex, ...]):
+def square(ctx, z: expansion):
     """Square on floating-point expansion"""
+    assert 0
+
+
+@definition("fma", domain="real")
+def fma_real(
+    ctx,
+    x: float,
+    y: float,
+    z: float,
+    functional: bool = True,
+    size: int = None,
+    possibly_zero_z: bool = True,
+    fix_overflow: bool = True,
+    algorithm: str = "a7",
+):
+    """Emulated fused add-multiply float expansion: x * y + z
+
+    Using Algorithm 9 from https://hal.science/hal-04575249 with
+    modifications to handle possible overflows and underflows.
+
+    Applicability:
+      x * y and x * y + z are both finite.
+
+    Accuracy:
+
+      The ULP distance between the result and correct value is always
+      <= 1.
+
+      fma(x, y, z) is exact (ULP distance is zero) for most inputs.
+      If not, either
+
+      - overflow occured in fma arithmetics (the return value is nan),
+        use fix_overflow to workaround overflow in Dekker product or 2Sum;
+      - or underflow occured in fma arithmetics, use possibly_zero_z to
+        fix z == 0 cases.
+    """
+    if algorithm == "a9":
+        # Algorithm 9 from https://hal.science/hal-04575249
+        #
+        # If fix_overflow is True, avoid overflow in Dekker product.
+        mh, ml = apmath.two_prod(ctx, x, y, fix_overflow=fix_overflow)
+        sh, sl = apmath.two_sum(ctx, mh, z, fix_overflow=fix_overflow)
+        vh, vl = apmath.two_sum(ctx, ml, sl)
+
+        p2 = fpa.is_one_or_three_times_power_of_two(ctx, vh, invert=True)
+        cond = ctx.logical_or(p2, vl == 0)
+
+        # (vh > 0 and vl > 0) or (vh <= 0 and vl <= 0)
+        # (vh > 0 and vl > 0) or (not (vh > 0) and not (vl > 0))
+        # (vh > 0 and vl > 0) or not (vh > 0 or vl > 0)
+        same_sign = ctx.logical_or(ctx.logical_and(vh > 0, vl > 0), ctx.logical_not(ctx.logical_or(vh > 0, vl > 0)))
+
+        C = ctx.constant(1, x)
+        if possibly_zero_z:
+            C = ctx.select(z == 0, ctx.constant(0, x), C)
+        C = ctx.select(cond, C, ctx.select(same_sign, ctx.constant(9 / 8, x), ctx.constant(7 / 8, x)))
+
+        return C * vh + sh
+    elif algorithm == "a7":
+        # Algorithm 7 from https://hal.science/hal-04624238
+        # It's faster than other algorithms.
+        mh, ml = apmath.two_prod(ctx, x, y, fix_overflow=fix_overflow)
+        sh, sl = apmath.two_sum(ctx, mh, z, fix_overflow=fix_overflow)
+        v = ml + sl
+        zh, zl = apmath.quick_two_sum(ctx, sh, v, fix_overflow=fix_overflow)
+        # zh, zl = apmath.two_sum(ctx, sh, v, fix_overflow=fix_overflow)
+        return zh + zl
+    elif algorithm == "a8":
+        # Algorithm 8 from https://hal.science/hal-04624238
+        mh, ml = apmath.two_prod(ctx, x, y, fix_overflow=fix_overflow)
+        xh, xl = apmath.two_sum(ctx, mh, ml, fix_overflow=fix_overflow)
+        sh, sl = apmath.two_sum(ctx, xh, z, fix_overflow=fix_overflow)
+        vh, vl = apmath.two_sum(ctx, xl, sl, fix_overflow=fix_overflow)
+        zh, zl = apmath.quick_two_sum(ctx, sh, vh, fix_overflow=fix_overflow)
+        w = vl + zl
+        st1 = zh + w
+        wpof2 = fpa.is_power_of_two(ctx, w)
+        wp = ctx.constant(3 / 2, x) * w
+        st2 = zh + wp
+
+        delta = w - zl
+        t = vl - delta
+        g = t * w
+        r = ctx.select(wpof2, ctx.select(st2 == zh, zh, ctx.select(t == 0, st1, ctx.select(g < 0, zh, st2))), st1)
+        return r
+    elif algorithm == "apmath":
+        # apmath native algorithm
+        mh, ml = apmath.two_prod(ctx, x, y, fix_overflow=fix_overflow)
+        hi, lo = apmath.renormalize(ctx, [z, mh, ml], functional=functional, size=2, fast=False, fix_overflow=fix_overflow)
+        return hi + lo
+    else:
+        raise ValueError(f"unsupported algorithm value (got '{algorithm}'), expected 'a9|a7|a8|apmath'")
+
+
+@definition("fma")
+def fma(ctx, x: float | complex, y: float | complex, z: float | complex):
+    """Fused add-multiply expansion"""
     assert 0

--- a/functional_algorithms/targets/base.py
+++ b/functional_algorithms/targets/base.py
@@ -73,6 +73,9 @@ class PrinterBase:
     def make_apply(self, expr, name, tab=""):
         raise NotImplementedError(type(self))
 
+    def make_getitem(self, var, index):
+        raise NotImplementedError(type(self))
+
     def show_value(self, var):
         return NotImplemented
 
@@ -95,7 +98,9 @@ class PrinterBase:
                                     self.make_assignment(None, a_.ref, self.make_constant(a_, self.tostring(a[i])))
                                 )
                             else:
-                                self.assignments.append(self.make_assignment(None, a_.ref, self.tostring(a[i])))
+                                self.assignments.append(
+                                    self.make_assignment(self.get_type(a_), a_.ref, self.make_getitem(a, i))
+                                )
                             self.defined_refs.add(a_.ref)
 
                 elif self.force_cast_arguments:
@@ -162,8 +167,13 @@ class PrinterBase:
                     self.assignments.append(stmt)
 
             if self.debug >= 1:
-                stmt = self.check_dtype(expr.ref, self.get_type(expr))
-                if isinstance(stmt, str):
-                    self.assignments.append(stmt)
+                t = expr.get_type()
+
+                if t.kind == "list":
+                    pass  # TODO
+                else:
+                    stmt = self.check_dtype(expr.ref, self.get_type(expr))
+                    if isinstance(stmt, str):
+                        self.assignments.append(stmt)
 
         return result

--- a/functional_algorithms/targets/numpy.py
+++ b/functional_algorithms/targets/numpy.py
@@ -264,6 +264,9 @@ class Printer(PrinterBase):
         typ = self.get_type(arg)
         return f"{arg}: {typ}"
 
+    def make_getitem(self, var, index):
+        return f"{var.ref}[{index}]"
+
     def show_value(self, var):
         return f'print("{var}=", {var})'
 

--- a/functional_algorithms/tests/test_apmath.py
+++ b/functional_algorithms/tests/test_apmath.py
@@ -1114,6 +1114,8 @@ def test_nztopk():
 
 
 def test_renormalize_max_size(dtype):
+    if dtype == numpy.longdouble:
+        pytest.skip("test not implemented")
 
     fi = numpy.finfo(dtype)
     max_size = (fi.maxexp - fi.minexp - fi.machep) // (-fi.negep - 1)
@@ -1125,4 +1127,3 @@ def test_renormalize_max_size(dtype):
 
     y = fa.apmath.renormalize(ctx, x)
     assert len(y) <= max_size
-    print(f"{len(y), max_size=}")

--- a/functional_algorithms/tests/test_apmath_algorithms.py
+++ b/functional_algorithms/tests/test_apmath_algorithms.py
@@ -1,4 +1,5 @@
 import numpy
+import itertools
 import functional_algorithms as fa
 from functional_algorithms import apmath_algorithms
 
@@ -28,3 +29,127 @@ def test_square(dtype_name):
     expected = fa.apmath.square(np_ctx, [samples], functional=True, size=2)
 
     numpy.testing.assert_equal(result, expected)
+
+
+_ranges = [
+    "0..eps",
+    "eps..sqrt_eps",
+    "sqrt_eps..1",
+    "1..1/sqrt_eps",
+    "1/sqrt_eps..sqrt_max",
+    "sqrt_max..max",
+]
+
+
+@pytest.mark.parametrize("xrange,yrange,zrange", list(itertools.product(_ranges, _ranges, _ranges)))
+def test_fma(dtype_name, xrange, yrange, zrange):
+    import mpmath
+
+    dtype = getattr(numpy, dtype_name)
+    fi = numpy.finfo(dtype)
+
+    def fix_range(r):
+        if isinstance(r, str):
+            mn, mx = r.split("..")
+            ns = fi.__dict__.copy()
+            ns.update(numpy=numpy, sqrt_max=numpy.sqrt(fi.max), sqrt_eps=numpy.sqrt(fi.eps), sqrt=numpy.sqrt)
+            mn = eval(mn, {}, ns)
+            mx = eval(mx, {}, ns)
+        else:
+            mn, mx = r
+        mn, mx = dtype(mn), dtype(mx)
+        return mn, mx
+
+    xrange = fix_range(xrange)
+    yrange = fix_range(yrange)
+    zrange = fix_range(zrange)
+
+    npctx = fa.utils.NumpyContext(dtype)
+    ctx = fa.Context(paths=[apmath_algorithms])
+
+    graph = ctx.trace(getattr(apmath_algorithms, "fma"), dtype, dtype, dtype)
+    graph = graph.rewrite(fa.targets.numpy, fa.rewrite, fa.rewrite)
+
+    func = fa.targets.numpy.as_function(graph, debug=0, force_cast_arguments=False)
+
+    size = 5 if dtype == numpy.float16 else 10
+    x, y, z = fa.utils.real_triple_samples(
+        (size, size, size),
+        dtype=dtype,
+        min_value=(xrange[0], yrange[0], zrange[0]),
+        max_value=(xrange[1], yrange[1], zrange[1]),
+        target_func="fma",
+        include_infinity=False,
+    )
+
+    x = numpy.concatenate((x, x))
+    y = numpy.concatenate((y, y))
+    z = numpy.concatenate((-z, z))
+
+    mp_ctx = mpmath.mp
+
+    def fma_mpmath(x, y, z):
+        # Reference implementation of FMA using mpmath.
+
+        # Warning: since mpmath does not support subnormals, when the
+        # FMA arithmetics involves subnormals, the results may
+        # slightly diverge from hardware FMA.
+        x_mp = fa.utils.float2mpf(mp_ctx, x)
+        y_mp = fa.utils.float2mpf(mp_ctx, y)
+        z_mp = fa.utils.float2mpf(mp_ctx, z)
+        return numpy.array(
+            [
+                fa.utils.mpf2float(dtype, mp_ctx.fadd(mp_ctx.fmul(x_, y_, exact=True), z_, exact=True))
+                for x_, y_, z_ in zip(x_mp, y_mp, z_mp)
+            ],
+            dtype=dtype,
+        )
+
+    reference_fma = None
+    if dtype in {numpy.float32, numpy.float64}:
+        # Try using pyfma.fma when available as it is much faster than
+        # fmp_mpmath and it will support subnormals.
+        try:
+            import pyfma
+
+            reference_fma = pyfma.fma
+        except ImportError:
+            pass
+
+    if reference_fma is None:
+        reference_fma = fma_mpmath
+
+    def issubnormal(x):
+        # assumes isfinite
+        ax = abs(x)
+        return numpy.logical_and(numpy.isfinite(x), numpy.logical_and(ax < fi.smallest_normal, ax > 0))
+
+    def hassubnormal(*args):
+        assert len(args) > 0
+        if len(args) == 1:
+            return issubnormal(args[0])
+        return numpy.logical_or(issubnormal(args[0]), hassubnormal(*args[1:]))
+
+    expected = reference_fma(x, y, z)
+    subnormals_mask = hassubnormal(expected, x, y, z, x * y)
+    normal_indices = numpy.where(numpy.logical_not(subnormals_mask))
+    subnormal_indices = numpy.where(subnormals_mask)
+
+    result = func(x, y, z)
+
+    ulps = fa.utils.diff_ulp(result, expected, flush_subnormals=True)
+
+    difference = result - expected
+
+    ind = numpy.where(ulps != 0)
+
+    if ind[0].size > 0:
+        fa.utils.show_ulp(ulps[normal_indices], title="No subnormals")
+        fa.utils.show_ulp(ulps[subnormal_indices], title="FMA aithmetics involves subnormals")
+
+    for i in ind[0]:
+        if numpy.isfinite(x[i] * y[i]):
+            assert ulps[i] <= 1
+        else:
+            assert not numpy.isfinite(result[i])
+            assert not numpy.isfinite(expected[i])

--- a/functional_algorithms/tests/test_floating_point_algorithms.py
+++ b/functional_algorithms/tests/test_floating_point_algorithms.py
@@ -168,6 +168,8 @@ def test_add_2sum(dtype):
     max_value = fi.max / dtype(2)
     min_value = -max_value
 
+    npctx = NumpyContext(dtype)
+
     ulp_counts = defaultdict(int)
     ulp_counts_native = defaultdict(int)
     samples = numpy.array(utils.real_samples(size, dtype=dtype, min_value=min_value, max_value=max_value))
@@ -178,7 +180,7 @@ def test_add_2sum(dtype):
             x_mp = utils.float2mpf(ctx, x)
             for y in samples:
                 xy = x + y
-                xyh, xyl = fpa.add_2sum(None, x, y)
+                xyh, xyl = fpa.add_2sum(npctx, x, y)
                 xyh_lst.append(xyh)
                 xyl_lst.append(xyl)
                 assert xyh == xy
@@ -197,7 +199,7 @@ def test_add_2sum(dtype):
                 if abs(x) < abs(y):
                     continue
 
-                xyh, xyl = fpa.add_2sum(None, x, y, fast=True)
+                xyh, xyl = fpa.add_2sum(npctx, x, y, fast=True)
                 assert xyh == xy
 
                 x_mp = utils.float2mpf(ctx, x)
@@ -210,7 +212,7 @@ def test_add_2sum(dtype):
 
     xyh_arr = numpy.array(xyh_lst)
     xyl_arr = numpy.array(xyl_lst)
-    xyh, xyl = fpa.add_2sum(None, samples.reshape(-1, samples.shape[-1]), samples.reshape(samples.shape[0], -1))
+    xyh, xyl = fpa.add_2sum(npctx, samples.reshape(-1, samples.shape[-1]), samples.reshape(samples.shape[0], -1))
 
     assert numpy.array_equal(xyh_arr, xyh.flatten())
     assert numpy.array_equal(xyl_arr, xyl.flatten(), equal_nan=True)
@@ -352,6 +354,7 @@ def test_accuracy(dtype, binary_op):
 
 
 def test_is_power_of_two(dtype):
+    npctx = NumpyContext(dtype)
     p = utils.get_precision(dtype)
     Q = dtype(1 << (p - 1))
     P = dtype((1 << (p - 1)) + 1)
@@ -361,24 +364,24 @@ def test_is_power_of_two(dtype):
     for e in range(min_e, max_e):
         x = dtype(2**e)
         assert utils.tobinary(x).startswith("1p") or x == 0
-        assert fpa.is_power_of_two(None, x, Q, P)
-        assert not fpa.is_power_of_two(None, x, Q, P, invert=True)
+        assert fpa.is_power_of_two(npctx, x, Q, P)
+        assert not fpa.is_power_of_two(npctx, x, Q, P, invert=True)
 
         x1 = numpy.nextafter(x, dtype(numpy.inf))
         while utils.tobinary(abs(x1)).startswith("1p"):
             x1 = numpy.nextafter(x1, dtype(numpy.inf))
-        assert not fpa.is_power_of_two(None, x1, Q, P)
-        assert fpa.is_power_of_two(None, x1, Q, P, invert=True)
+        assert not fpa.is_power_of_two(npctx, x1, Q, P)
+        assert fpa.is_power_of_two(npctx, x1, Q, P, invert=True)
 
         x1 = numpy.nextafter(x, dtype(-numpy.inf))
         while utils.tobinary(abs(x1)).startswith("1p") or x1 == 0:
             x1 = numpy.nextafter(x1, dtype(-numpy.inf))
-        assert not fpa.is_power_of_two(None, x1, Q, P)
-        assert fpa.is_power_of_two(None, x1, Q, P, invert=True)
+        assert not fpa.is_power_of_two(npctx, x1, Q, P)
+        assert fpa.is_power_of_two(npctx, x1, Q, P, invert=True)
 
 
 def test_add_3sum(dtype):
-    np_ctx = NumpyContext()
+    np_ctx = NumpyContext(dtype)
     import mpmath
 
     max_valid_ulp_count = 1
@@ -432,7 +435,7 @@ def test_add_3sum(dtype):
 
 
 def test_add_4sum(dtype):
-    np_ctx = NumpyContext()
+    np_ctx = NumpyContext(dtype)
     import mpmath
 
     max_valid_ulp_count = 1

--- a/functional_algorithms/typesystem.py
+++ b/functional_algorithms/typesystem.py
@@ -103,6 +103,13 @@ class Type:
             kind = "integer"
         elif "boolean" in {self.kind, other.kind}:
             kind = "boolean"
+        elif self.kind == "list" and other.kind == "list":
+            if len(self.param) < len(other.param):
+                assert self.param == other.param[: len(self.param)]
+                return other
+            else:
+                assert self.param[: len(other.param)] == other.param
+                return self
         else:
             raise NotImplementedError((self.kind, other.kind))
         bits = max([t.bits for t in [self, other] if t.kind == kind and t.bits is not None] or [None])

--- a/functional_algorithms/utils.py
+++ b/functional_algorithms/utils.py
@@ -1623,7 +1623,7 @@ def real_samples(
       actual size of the returned array may differ from size, except
       when both min/max_value are specified with the same sign.
     dtype:
-      Floating-point type: float32, float64.
+      Floating-point type: float16, float32, float64.
     include_infinity: bool
       When True, samples include signed infinities.
     include_zero: bool
@@ -1638,9 +1638,20 @@ def real_samples(
     nonnegative: bool
       When True, finite samples are all non-negative.
     min_value, max_value: dtype, None
-      When min_value or max_value is specified, use for constructing
-      uniform samples. Parameters include_infinity, include_nan,
-      include_huge, and nonnegative are silently ignored.
+      When min_value or max_value is specified, return log-uniformly
+      distributed samples within specified bounds. Parameters
+      include_infinity, include_nan, include_huge, and nonnegative are
+      silently ignored.
+
+      When max_value is specified then the default min_value is
+      smallest normal (max_value > 0) or negative largest value
+      (max_value < 0). When min_value is specified then the default
+      max_value is largest finite value (min_value > 0) or negative
+      smallest normal (min_value < 0).
+
+      When min_value and max_value is not specified, return
+      log-uniformly distributed samples within bounds specified by
+      include_* and nonnegative parameters.
     unique: bool
       When True, all samples are unique. Otherwise, allow repeated
       sample values for predictability of the number of samples.
@@ -1655,15 +1666,23 @@ def real_samples(
     num = size // 2 if not nonnegative and not user_specified_bounds else size
     if include_infinity and not user_specified_bounds:
         num -= 1
+    assert not isinstance(min_value, tuple)
+    assert not isinstance(max_value, tuple)
 
     min_pos_value = dtype(fi.smallest_subnormal if include_subnormal else fi.smallest_normal)
     if min_value is None:
-        min_value = min_pos_value
+        if max_value is not None and max_value < 0:
+            min_value = -dtype(fi.max)
+        else:
+            min_value = min_pos_value
     else:
         min_value = dtype(min_value)
 
     if max_value is None:
-        max_value = dtype(fi.max)
+        if min_value is not None and min_value < 0:
+            max_value = -min_pos_value
+        else:
+            max_value = dtype(fi.max)
     else:
         max_value = dtype(max_value)
 
@@ -1845,7 +1864,7 @@ def complex_samples(
     include_subnormal: bool
     include_nan: bool
     nonnegative: bool
-    min_real_value, max_real_value, min_imag_value, max_imag_value: dtype
+    min_real_value, max_real_value, min_imag_value, max_imag_value: dtype, tuple, None
     """
     if isinstance(dtype, str):
         dtype = getattr(numpy, dtype)
@@ -1882,6 +1901,20 @@ def complex_samples(
     return real_part + imag_part  # TODO: avoid arithmetic operations
 
 
+def _fix_limit_value(value, dims=1):
+    if value is None:
+        values = (None,) * dims
+    elif isinstance(value, number_types):
+        values = (value,) * dims
+    elif isinstance(value, tuple):
+        assert len(value) == dims
+        values = value
+    else:
+        assert 0, type(value)  # not implemented
+
+    return values
+
+
 def real_pair_samples(
     size=(10, 10),
     dtype=numpy.float32,
@@ -1891,6 +1924,8 @@ def real_pair_samples(
     include_nan=False,
     include_huge=True,
     nonnegative=False,
+    min_value=None,
+    max_value=None,
 ):
     """Return a pair of 1-D arrays of real line samples.
 
@@ -1905,7 +1940,11 @@ def real_pair_samples(
     include_subnormal: bool
     include_nan: bool
     nonnegative: bool
+    min_value, max_value: None, dtype, tuple
     """
+    min_values = _fix_limit_value(min_value, dims=2)
+    max_values = _fix_limit_value(max_value, dims=2)
+
     s1 = real_samples(
         size=size[0],
         dtype=dtype,
@@ -1915,6 +1954,8 @@ def real_pair_samples(
         include_nan=include_nan,
         nonnegative=nonnegative,
         include_huge=include_huge,
+        min_value=min_values[0],
+        max_value=max_values[0],
     )
     s2 = real_samples(
         size=size[1],
@@ -1925,6 +1966,8 @@ def real_pair_samples(
         include_nan=include_nan,
         nonnegative=nonnegative,
         include_huge=include_huge,
+        min_value=min_values[1],
+        max_value=max_values[1],
     )
     s1, s2 = s1.reshape(1, -1).repeat(s2.size, 0).flatten(), s2.repeat(s1.size)
     return s1, s2
@@ -1939,6 +1982,10 @@ def complex_pair_samples(
     include_nan=False,
     include_huge=True,
     nonnegative=False,
+    min_real_value=None,
+    max_real_value=None,
+    min_imag_value=None,
+    max_imag_value=None,
 ):
     """Return a pair of 2-D arrays of complex plane samples.
 
@@ -1954,7 +2001,12 @@ def complex_pair_samples(
     include_subnormal: bool
     include_nan: bool
     nonnegative: bool
+    min_real_value, max_real_value, min_imag_value, max_imag_value: dtype, tuple, None
     """
+    min_real_values = _fix_limit_value(min_real_value, dims=2)
+    max_real_values = _fix_limit_value(max_real_value, dims=2)
+    min_imag_values = _fix_limit_value(min_imag_value, dims=2)
+    max_imag_values = _fix_limit_value(max_imag_value, dims=2)
     s1 = complex_samples(
         size=size[0],
         dtype=dtype,
@@ -1964,6 +2016,10 @@ def complex_pair_samples(
         include_nan=include_nan,
         include_huge=include_huge,
         nonnegative=nonnegative,
+        min_real_value=min_real_values[0],
+        max_real_value=max_real_values[0],
+        min_imag_value=min_imag_values[0],
+        max_imag_value=max_imag_values[0],
     )
     s2 = complex_samples(
         size=size[1],
@@ -1974,6 +2030,10 @@ def complex_pair_samples(
         include_nan=include_nan,
         include_huge=include_huge,
         nonnegative=nonnegative,
+        min_real_value=min_real_values[1],
+        max_real_value=max_real_values[1],
+        min_imag_value=min_imag_values[1],
+        max_imag_value=max_imag_values[1],
     )
     shape1 = s1.shape
     shape2 = s2.shape
@@ -2083,6 +2143,96 @@ def expansion_samples(
             if numpy.isfinite(s):
                 lst.append(e)
     return lst
+
+
+def real_triple_samples(
+    size=(10, 10, 10),
+    dtype=numpy.float32,
+    include_infinity=True,
+    include_zero=True,
+    include_subnormal=False,
+    include_nan=False,
+    include_huge=True,
+    nonnegative=False,
+    min_value=None,
+    max_value=None,
+):
+    """Return a triple of 1-D arrays of real line samples.
+
+    Parameters
+    ----------
+    size : tuple(int, int, int)
+      Initial size of the samples array. A minimum value is (6, 6, 6). The
+      actual size of the returned array is approximately size[0] * size[1] * size[2].
+    dtype:
+    include_infinity: bool
+    include_zero: bool
+    include_subnormal: bool
+    include_nan: bool
+    nonnegative: bool
+    """
+    if min_value is None:
+        min_values = (None,) * 3
+    elif isinstance(min_value, number_types):
+        min_values = (min_value,) * 3
+    elif isinstance(min_value, tuple):
+        assert len(min_value) == 3
+        min_values = min_value
+    else:
+        assert 0, type(min_value)  # not implemented
+
+    if max_value is None:
+        max_values = (None,) * 3
+    elif isinstance(max_value, number_types):
+        max_values = (max_value,) * 3
+    elif isinstance(max_value, tuple):
+        assert len(max_value) == 3
+        max_values = max_value
+    else:
+        assert 0, type(max_value)  # not implemented
+
+    s1 = real_samples(
+        size=size[0],
+        dtype=dtype,
+        include_infinity=include_infinity,
+        include_zero=include_zero,
+        include_subnormal=include_subnormal,
+        include_nan=include_nan,
+        nonnegative=nonnegative,
+        include_huge=include_huge,
+        min_value=min_values[0],
+        max_value=max_values[0],
+    )
+    s2 = real_samples(
+        size=size[1],
+        dtype=dtype,
+        include_infinity=include_infinity,
+        include_zero=include_zero,
+        include_subnormal=include_subnormal,
+        include_nan=include_nan,
+        nonnegative=nonnegative,
+        include_huge=include_huge,
+        min_value=min_values[1],
+        max_value=max_values[1],
+    )
+    s3 = real_samples(
+        size=size[2],
+        dtype=dtype,
+        include_infinity=include_infinity,
+        include_zero=include_zero,
+        include_subnormal=include_subnormal,
+        include_nan=include_nan,
+        nonnegative=nonnegative,
+        include_huge=include_huge,
+        min_value=min_values[2],
+        max_value=max_values[2],
+    )
+    s1, s2, s3 = (
+        s1.reshape(-1, 1, 1).repeat(s2.size, 1).repeat(s3.size, 2).flatten(),
+        s2.reshape(1, -1, 1).repeat(s1.size, 0).repeat(s3.size, 2).flatten(),
+        s3.reshape(1, 1, -1).repeat(s1.size, 0).repeat(s2.size, 1).flatten(),
+    )
+    return s1, s2, s3
 
 
 def iscomplex(value):


### PR DESCRIPTION
This PR adds
- `real_triple_samples` utility and testing for min/max_value arguments;
- `fix_overflow=` argument to `add_2sum` and `mul_dekker` and their consumers to extend their usage on large arguments;
- `fma` apmath algorithm that emulates fused multiply-add (FMA). Using modified algorithm 9 from https://hal.science/hal-04575249, algorithms 7 and 8 from https://hal.science/hal-04624238, and an algorithm using apmath expansions. The algorithms differ on minimizing the size of the set `ULP difference(result, reference) == 1`: the first algorithm (9) gives the minimal size while the second gives the highest performance;
- new operation `len` for expansion expressions;
- support for predicate algorithms (functions returning `bool` value);
- predicate algorithms `is_power_of_two`, `is_one_or_three_times_power_of_two`;
- `target_func=` argument to `real_triple_samples` to minimize the size of samples using the symmetries of the function, currently only `target_func="fma"` is supported;
- number of improvements and bug fixes to fa internals.
